### PR TITLE
Sharing Collection Support

### DIFF
--- a/Jewel.xcodeproj/project.pbxproj
+++ b/Jewel.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		D26077BF24605D59005883ED /* SlotDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26077BE24605D59005883ED /* SlotDetail.swift */; };
 		D26B5622243E80450098E9E4 /* AlbumDetailCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26B5621243E80450098E9E4 /* AlbumDetailCompact.swift */; };
 		D26B5624243E8DB00098E9E4 /* PrimaryPlaybackLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26B5623243E8DB00098E9E4 /* PrimaryPlaybackLink.swift */; };
+		D26BAFC1246F3F3F00F226CD /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26BAFC0246F3F3F00F226CD /* ShareSheet.swift */; };
+		D26BAFC3246F404700F226CD /* ShareableSlot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26BAFC2246F404700F226CD /* ShareableSlot.swift */; };
 		D27371C324571828005CC5EF /* JewelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27371C224571828005CC5EF /* JewelError.swift */; };
 		D28358832451D3C700411AC9 /* Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28358822451D3C700411AC9 /* Search.swift */; };
 		D28358872452D3CF00411AC9 /* SearchResultsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28358862452D3CF00411AC9 /* SearchResultsList.swift */; };
@@ -95,6 +97,8 @@
 		D26077BE24605D59005883ED /* SlotDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotDetail.swift; sourceTree = "<group>"; };
 		D26B5621243E80450098E9E4 /* AlbumDetailCompact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetailCompact.swift; sourceTree = "<group>"; };
 		D26B5623243E8DB00098E9E4 /* PrimaryPlaybackLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryPlaybackLink.swift; sourceTree = "<group>"; };
+		D26BAFC0246F3F3F00F226CD /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
+		D26BAFC2246F404700F226CD /* ShareableSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableSlot.swift; sourceTree = "<group>"; };
 		D27371C224571828005CC5EF /* JewelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JewelError.swift; sourceTree = "<group>"; };
 		D28358822451D3C700411AC9 /* Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
 		D28358862452D3CF00411AC9 /* SearchResultsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsList.swift; sourceTree = "<group>"; };
@@ -252,6 +256,7 @@
 				D201C45F246AAD3800A5FC87 /* AdditionalPlaybackLinks.swift */,
 				D2D40B4E245738220018E066 /* AlbumTrackList.swift */,
 				D22666122462F5940031C9A8 /* DiscTrackList.swift */,
+				D26BAFC0246F3F3F00F226CD /* ShareSheet.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -306,6 +311,7 @@
 				D22318BC246C5B5C0033B8A5 /* Source.swift */,
 				D2BF19C4246D4F1E008B09D3 /* SourceProvider.swift */,
 				D2A55CCE246839980007CD1F /* OdesliResponse.swift */,
+				D26BAFC2246F404700F226CD /* ShareableSlot.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -482,6 +488,7 @@
 				D2A55CCF246839980007CD1F /* OdesliResponse.swift in Sources */,
 				D2E690FA2450ECBB00B981F2 /* EmptySlot.swift in Sources */,
 				D22C4552243DDE490001481D /* Home.swift in Sources */,
+				D26BAFC1246F3F3F00F226CD /* ShareSheet.swift in Sources */,
 				D2A31B05246308B800D6BF4A /* Start.swift in Sources */,
 				D22666132462F5940031C9A8 /* DiscTrackList.swift in Sources */,
 				D2D40B4F245738220018E066 /* AlbumTrackList.swift in Sources */,
@@ -489,6 +496,7 @@
 				D2D5875E244E391200E982E8 /* UserData.swift in Sources */,
 				D29C76002459662F005BE357 /* SearchBar.swift in Sources */,
 				D29C760224598F06005BE357 /* SearchProvider.swift in Sources */,
+				D26BAFC3246F404700F226CD /* ShareableSlot.swift in Sources */,
 				D22C4524243DD8B00001481D /* SceneDelegate.swift in Sources */,
 				D26077BF24605D59005883ED /* SlotDetail.swift in Sources */,
 				D230CC562460CC2C00FD811F /* Footer.swift in Sources */,

--- a/Jewel/Helpers/Screenshots/UserData+Screenshots.swift
+++ b/Jewel/Helpers/Screenshots/UserData+Screenshots.swift
@@ -16,7 +16,7 @@ extension UserData {
         for slotIndex in 0..<albums!.data!.count {
             let source = Source(sourceReference: albums!.data![slotIndex].id, album: albums!.data![slotIndex])
             let newSlot = Slot(source: source)
-            self.collection.slots[slotIndex] = newSlot
+            self.activeCollection.slots[slotIndex] = newSlot
         }
     }
     

--- a/Jewel/Helpers/SearchProvider.swift
+++ b/Jewel/Helpers/SearchProvider.swift
@@ -16,11 +16,11 @@ class SearchProvider: ObservableObject {
     func search(searchTerm: String) {
         if let developerToken = Bundle.main.infoDictionary?["APPLE_MUSIC_API_TOKEN"] as? String {
             let store = HMV(storefront: .unitedKingdom, developerToken: developerToken)
-
+            
             store.search(term: searchTerm, limit: 20, types: [.albums]) { storeResults, error in
-              DispatchQueue.main.async {
-                self.results = storeResults?.albums?.data
-              }
+                DispatchQueue.main.async {
+                    self.results = storeResults?.albums?.data
+                }
             }
         }
     }

--- a/Jewel/Jewel.entitlements
+++ b/Jewel/Jewel.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:jewel.breakbeat.io</string>
+	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array/>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>

--- a/Jewel/Models/Collection.swift
+++ b/Jewel/Models/Collection.swift
@@ -9,6 +9,13 @@
 import Foundation
 
 class Collection: Codable {
-    var name = "My Collection"
-    var slots = [Slot]()
+    var name: String
+    var curator = "A Music Lover"
+    var slots = [Slot](repeating: Slot(), count: 8)
+    var editable: Bool
+    
+    init(name: String, editable: Bool) {
+        self.name = name
+        self.editable = editable
+    }
 }

--- a/Jewel/Models/Collection.swift
+++ b/Jewel/Models/Collection.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Collection: Codable {
+class Collection: Codable {
     var name = "My Collection"
     var slots = [Slot]()
 }

--- a/Jewel/Models/Preferences.swift
+++ b/Jewel/Models/Preferences.swift
@@ -10,10 +10,7 @@ import Foundation
 
 struct Preferences: Codable {
     
-    var preferredMusicPlatform: Int
-    var curatorName: String
+    var preferredMusicPlatform = 0
     var debugMode = false
-    
-    static let `default` = Self(preferredMusicPlatform: 0, curatorName: "A Music Lover")
     
 }

--- a/Jewel/Models/Preferences.swift
+++ b/Jewel/Models/Preferences.swift
@@ -9,6 +9,11 @@
 import Foundation
 
 struct Preferences: Codable {
-    var preferredMusicPlatform = 0 // Apple Music
+    
+    var preferredMusicPlatform: Int
+    var curatorName: String
     var debugMode = false
+    
+    static let `default` = Self(preferredMusicPlatform: 0, curatorName: "A Music Lover")
+    
 }

--- a/Jewel/Models/ShareableSlot.swift
+++ b/Jewel/Models/ShareableSlot.swift
@@ -1,0 +1,35 @@
+//
+//  ShareableCollection.swift
+//  Jewel
+//
+//  Created by Greg Hepworth on 14/05/2020.
+//  Copyright © 2020 Breakbeat Ltd. All rights reserved.
+//
+import Foundation
+
+struct ShareableCollection: Codable {
+    let schemaName = "jewel-shared-collection"
+    let schemaVersion: Decimal = 1.1
+    let collectionName: String
+    let collectionCurator: String
+    let collection: [ShareableSlot?]
+    
+    enum CodingKeys: String, CodingKey {
+        case schemaName = "sn"
+        case schemaVersion = "sv"
+        case collectionName = "cn"
+        case collectionCurator = "cc"
+        case collection = "c"
+    }
+    
+}
+
+struct ShareableSlot: Codable {
+    let sourceProvider: SourceProvider
+    let sourceRef: String
+    
+    enum CodingKeys: String, CodingKey {
+        case sourceProvider = "sp"
+        case sourceRef = "sr"
+    }
+}

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -130,6 +130,7 @@ class UserData: ObservableObject {
                     if let baseUrl = album?.attributes?.url {
                         self.populatePlatformLinks(baseUrl: baseUrl, slotIndex: slotIndex)
                     }
+                    self.objectWillChange.send()
                 }
             }
         })
@@ -167,6 +168,7 @@ class UserData: ObservableObject {
     func deleteAlbumFromSlot(slotIndex: Int) {
         let emptySlot = Slot()
         self.collection.slots[slotIndex] = emptySlot
+        self.objectWillChange.send()
     }
     
     func deleteAll() {

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -8,7 +8,8 @@
 
 // TODO
 // * How can I not initialise activeCollection seeing as it just points to somethign else.
-// * lodUserData should be able to be reduce to one loop instead of three identical calls
+// * loadUserData should be able to be reduce to one loop instead of three identical calls
+// * when leaving options I am saving everything - seems heavy handed - how can I be smarter and only save what changed?!?
 
 
 import Foundation
@@ -121,14 +122,9 @@ class UserData: ObservableObject {
     
     func collectionChanged() {
         self.objectWillChange.send()
-        switch activeCollectionRef {
-            case "user":
-                self.saveUserData(key: "jewelCollection")
-            case "shared":
-                self.saveUserData(key: "jewelSharedCollection")
-            default:
-                return
-        }
+        // just save everything at the moment even if not active - the whole repetition of stuff needs to be changed anyway!
+        self.saveUserData(key: "jewelCollection")
+        self.saveUserData(key: "jewelSharedCollection")
     }
     
     func preferencesChanged() {

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -8,18 +8,12 @@
 
 // TODO
 // * How can I not initialise activeCollection seeing as it just points to somethign else? make it optional
-// switch the activeCollectionRef to a Bool rather than a string.
 // * loadUserData should be able to be reduce to one loop instead of three identical calls
 // * when leaving options I am saving everything - seems heavy handed - how can I be smarter and only save what changed?!?
 // * should i do additonal checks on an non-editable collection?  Currently I just hide the buttons, but the func itself isn't disabled
 // * split out the platofrm links so it can be executed seperately from loading an album - e.g. when curing a candidate collection, no need to waste time getting htem at that point
-// * need an eject all for the shared album
-// * is it possible to switch to the shared collection view if a universal link is clicked so that user can see waht the might be replaceing?
-// * remove the candidate collection when no longer needed
-// * tidy it all up - including the names!
-// * Don't share an empty album! duh
 
-// do all the renaming - album to content, etc
+// * tidy it all up - including the names!
 
 // disable share on their collection - OR BETTER SOMEHOW MARK IT AS RESHARED?
 
@@ -32,7 +26,7 @@ import HMV
 
 class UserData: ObservableObject {
     
-    @Published var prefs = Preferences.default
+    @Published var prefs = Preferences()
     
     @Published var userCollection = Collection(name: "My Collection", editable: true)
     @Published var userCollectionActive = true {
@@ -255,8 +249,8 @@ class UserData: ObservableObject {
         }
         
         let shareableCollection = ShareableCollection(
-            collectionName: activeCollection.name == "My Collection" ? "\(prefs.curatorName)'s Collection" : activeCollection.name,
-            collectionCurator: prefs.curatorName,
+            collectionName: activeCollection.name == "My Collection" ? "\(activeCollection.curator)'s Collection" : activeCollection.name,
+            collectionCurator: activeCollection.curator,
             collection: shareableSlots
         )
         

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -14,7 +14,7 @@
 // * should i do additonal checks on an non-editable collection?  Currently I just hide the buttons, but the func itself isn't disabled
 // * split out the platofrm links so it can be executed seperately from loading an album - e.g. when curing a candidate collection, no need to waste time getting htem at that point
 // * need an eject all for the shared album
-
+// * is it possible to switch to the shared collection view if a universal link is clicked so that user can see waht the might be replaceing?
 
 // do all the renaming - album to content, etc
 // get rid of loadRecommendations - merge with loadRecievedCollection
@@ -304,6 +304,7 @@ class UserData: ObservableObject {
             }
         }
         
+        self.switchCollectionTo(collectionRef: "shared")
         sharedCollectionCued = true
         
     }

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -12,6 +12,25 @@
 // * when leaving options I am saving everything - seems heavy handed - how can I be smarter and only save what changed?!?
 
 
+// re-enable platform links
+// disable share on their collection - OR BETTER SOMEHOW MARK IT AS RESHARED?
+// when sharing, if name is set to my Collection, change it to something else
+// hide/disable the their collection tab if it is empty - or show some kind of overlay?
+// clear the shared collection url once loaded
+// when recieved a URL, switch to their collection then apply it
+// check button position on navbar
+// ability to change colletion name by tapping title instead of going to options
+// not nice that when changing collectionname need to then also update the activeCollection - be nice if it just updated.  Maybe on the didSet could refresh the active collection for changes that happen in the background?  how will platformLinks work?  (presumably if they are applied to teh activeCollection then they proliforate through ....
+// when recieving the shared collection, can i decode and create it into a collection so it can be queired then the alerts can be much nicer?
+//
+// DONE their collection restrictions
+// DONE if their collcetion is active, then disable things!
+// DONE disable '+' on an empty slot
+// DONE disable the 'swap' and 'eject' buttons
+// DONE in options, make sure Collcetion Name is only bound to My Collcetion
+// NONEED - check size on iphone 8 - withotu segmented control, no changes have been made
+// WONTDO - why doesn't the segmented control move off the screen? - moved it to a 'switch' button instead
+
 import Foundation
 import HMV
 
@@ -19,7 +38,7 @@ class UserData: ObservableObject {
 
     @Published var prefs = Preferences.default
     @Published var userCollection = Collection(name: "My Collection", editable: true)
-    @Published var sharedCollection = Collection(name: "Their Collection", editable: true)
+    @Published var sharedCollection = Collection(name: "Their Collection", editable: false)
     
     @Published var activeCollectionRef = "user"
     @Published var activeCollection = Collection(name: "My Collection", editable: true) // TODO: Make this optional so I don't haev to give it a crap one just to instantly get rid of it.

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -7,11 +7,12 @@
 //
 
 // TODO
-// * How can I not initialise activeCollection seeing as it just points to somethign else.
+// * How can I not initialise activeCollection seeing as it just points to somethign else? make it optional
+
 // * loadUserData should be able to be reduce to one loop instead of three identical calls
 // * when leaving options I am saving everything - seems heavy handed - how can I be smarter and only save what changed?!?
 // * should i do additonal checks on an non-editable collection?  Currently I just hide the buttons, but the func itself isn't disabled
-// Load a shared collection into sharedCollection!
+// do all the renaming - album to content, etc
 
 // disable share on their collection - OR BETTER SOMEHOW MARK IT AS RESHARED?
 // when sharing, if name is set to my Collection, change it to something else
@@ -246,6 +247,32 @@ class UserData: ObservableObject {
         userDefaults.synchronize()
         exit(1)
     }
+    
+    func createShareUrl() -> URL {
+          
+          var shareableSlots = [ShareableSlot?]()
+
+          for slot in activeCollection.slots {
+              if let content = slot.source?.album {
+                let slot = ShareableSlot(sourceProvider: slot.source!.sourceProvider, sourceRef: content.id)
+                  shareableSlots.append(slot)
+              } else {
+                  shareableSlots.append(nil)
+              }
+          }
+
+          let shareableCollection = ShareableCollection(
+              collectionName: activeCollection.name,
+              collectionCurator: prefs.curatorName,
+              collection: shareableSlots
+          )
+
+          let encoder = JSONEncoder()
+          let shareableCollectionJson = try! encoder.encode(shareableCollection)
+          
+          return URL(string: "https://jewel.breakbeat.io/share/?c=\(shareableCollectionJson.base64EncodedString())")!
+          
+      }
     
     func loadRecommendations() {
         

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -20,7 +20,7 @@
 // * Don't share an empty album! duh
 
 // do all the renaming - album to content, etc
-// get rid of loadRecommendations - merge with loadRecievedCollection
+
 // disable share on their collection - OR BETTER SOMEHOW MARK IT AS RESHARED?
 // when sharing, if name is set to my Collection, change it to something else
 // hide/disable the their collection tab if it is empty - or show some kind of overlay?
@@ -253,7 +253,7 @@ class UserData: ObservableObject {
         }
         
         let shareableCollection = ShareableCollection(
-            collectionName: activeCollection.name,
+            collectionName: activeCollection.name == "My Collection" ? "\(prefs.curatorName)'s Collection" : activeCollection.name,
             collectionCurator: prefs.curatorName,
             collection: shareableSlots
         )

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -6,21 +6,6 @@
 //  Copyright © 2020 Breakbeat Limited. All rights reserved.
 //
 
-// TODO
-// * How can I not initialise activeCollection seeing as it just points to somethign else? make it optional
-// * loadUserData should be able to be reduce to one loop instead of three identical calls
-// * when leaving options I am saving everything - seems heavy handed - how can I be smarter and only save what changed?!?
-// * should i do additonal checks on an non-editable collection?  Currently I just hide the buttons, but the func itself isn't disabled
-// * split out the platofrm links so it can be executed seperately from loading an album - e.g. when curing a candidate collection, no need to waste time getting htem at that point
-
-// * tidy it all up - including the names!
-
-// disable share on their collection - OR BETTER SOMEHOW MARK IT AS RESHARED?
-
-// ability to change colletion name by tapping title instead of going to options
-// not nice that when changing collectionname need to then also update the activeCollection - be nice if it just updated.  Maybe on the didSet could refresh the active collection for changes that happen in the background?  how will platformLinks work?  (presumably if they are applied to teh activeCollection then they proliforate through ....
-
-
 import Foundation
 import HMV
 
@@ -170,9 +155,9 @@ class UserData: ObservableObject {
                     let source = Source(sourceReference: album!.id, album: album)
                     let newSlot = Slot(source: source)
                     collection.slots[slotIndex] = newSlot
-                    //                    if let baseUrl = album?.attributes?.url {
-                    //                        self.populatePlatformLinks(baseUrl: baseUrl, slotIndex: slotIndex)
-                    //                    }
+                    if let baseUrl = album?.attributes?.url {
+                        self.populatePlatformLinks(baseUrl: baseUrl, slotIndex: slotIndex)
+                    }
                     self.collectionChanged()
                 }
             }

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -222,7 +222,7 @@ class UserData: ObservableObject {
         }.resume()
     }
     
-    func deleteAlbumFromSlot(slotIndex: Int) {
+    func ejectSourceFromSlot(slotIndex: Int) {
         let emptySlot = Slot()
         self.activeCollection.slots[slotIndex] = emptySlot
         self.collectionChanged()
@@ -230,7 +230,7 @@ class UserData: ObservableObject {
     
     func deleteAll() {
         for slotIndex in 0..<activeCollection.slots.count {
-            deleteAlbumFromSlot(slotIndex: slotIndex)
+            ejectSourceFromSlot(slotIndex: slotIndex)
         }
     }
     

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -15,6 +15,9 @@
 // * split out the platofrm links so it can be executed seperately from loading an album - e.g. when curing a candidate collection, no need to waste time getting htem at that point
 // * need an eject all for the shared album
 // * is it possible to switch to the shared collection view if a universal link is clicked so that user can see waht the might be replaceing?
+// * remove the candidate collection when no longer needed
+// * tidy it all up - including the names!
+// * Don't share an empty album! duh
 
 // do all the renaming - album to content, etc
 // get rid of loadRecommendations - merge with loadRecievedCollection

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -288,14 +288,17 @@ class UserData: ObservableObject {
             }
         }
         
-        self.userCollectionActive = false
+        userCollectionActive = false
         sharedCollectionCued = true
         
     }
     
     func loadCandidateCollection() {
         if candidateCollection != nil {
+            print("applying candidate collection to shared")
             sharedCollection = candidateCollection!
+            userCollectionActive = false
+            collectionChanged()
         }
     }
     

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -11,7 +11,7 @@ import HMV
 
 class UserData: ObservableObject {
 
-    @Published var prefs = Preferences()
+    @Published var prefs = Preferences.default
     @Published var collection = Collection()
     
     private let numberOfSlots = 8

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -295,7 +295,6 @@ class UserData: ObservableObject {
     
     func loadCandidateCollection() {
         if candidateCollection != nil {
-            print("applying candidate collection to shared")
             sharedCollection = candidateCollection!
             userCollectionActive = false
             collectionChanged()
@@ -304,21 +303,16 @@ class UserData: ObservableObject {
     
     func loadRecommendations() {
         
-        let request = URLRequest(url: URL(string: "https://breakbeat.io/jewel/recommendations.json")!)
+        let request = URLRequest(url: URL(string: "https://jewel.breakbeat.io/recommendations.json")!)
         
         URLSession.shared.dataTask(with: request) { data, response, error in
             if let data = data {
-                if let decodedResponse = try? JSONDecoder().decode([String].self, from: data) {
+                if let decodedResponse = try? JSONDecoder().decode(ShareableCollection.self, from: data) {
                     // we have good data – go back to the main thread
                     DispatchQueue.main.async {
-                        for (index, albumId) in decodedResponse.enumerated() {
-                            self.addAlbumToSlot(albumId: albumId, collection: self.sharedCollection, slotIndex: index)
-                        }
-
-                        // everything is good, so we can exit
-                        self.userCollectionActive = false
+                        self.cueCandidateCollection(recievedCollection: decodedResponse)
+                        return
                     }
-                    return
                 }
             }
 

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -274,6 +274,10 @@ class UserData: ObservableObject {
           
       }
     
+    func processSharedCollection(sharedCollectionUrl: URL) {
+        print(sharedCollectionUrl.absoluteString)
+    }
+    
     func loadRecommendations() {
         
         let request = URLRequest(url: URL(string: "https://breakbeat.io/jewel/recommendations.json")!)

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -23,13 +23,8 @@
 
 // disable share on their collection - OR BETTER SOMEHOW MARK IT AS RESHARED?
 
-// hide/disable the their collection tab if it is empty - or show some kind of overlay?
-// clear the shared collection url once loaded
-// when recieved a URL, switch to their collection then apply it
-// check button position on navbar
 // ability to change colletion name by tapping title instead of going to options
 // not nice that when changing collectionname need to then also update the activeCollection - be nice if it just updated.  Maybe on the didSet could refresh the active collection for changes that happen in the background?  how will platformLinks work?  (presumably if they are applied to teh activeCollection then they proliforate through ....
-// when recieving the shared collection, can i decode and create it into a collection so it can be queired then the alerts can be much nicer?
 
 
 import Foundation
@@ -303,6 +298,7 @@ class UserData: ObservableObject {
     func loadCandidateCollection() {
         if candidateCollection != nil {
             sharedCollection = candidateCollection!
+            candidateCollection = nil
             userCollectionActive = false
             collectionChanged()
         }

--- a/Jewel/Models/UserData.swift
+++ b/Jewel/Models/UserData.swift
@@ -22,7 +22,7 @@
 // do all the renaming - album to content, etc
 
 // disable share on their collection - OR BETTER SOMEHOW MARK IT AS RESHARED?
-// when sharing, if name is set to my Collection, change it to something else
+
 // hide/disable the their collection tab if it is empty - or show some kind of overlay?
 // clear the shared collection url once loaded
 // when recieved a URL, switch to their collection then apply it
@@ -226,10 +226,17 @@ class UserData: ObservableObject {
         self.collectionChanged()
     }
     
-    func deleteAll() {
+    func ejectUserCollection() {
+        userCollectionActive = true
         for slotIndex in 0..<activeCollection.slots.count {
             ejectSourceFromSlot(slotIndex: slotIndex)
         }
+    }
+    
+    func ejectSharedCollection() {
+        sharedCollection = Collection(name: "Their Collection", editable: false)
+        self.collectionChanged()
+        userCollectionActive = true
     }
     
     func reset() {

--- a/Jewel/SceneDelegate.swift
+++ b/Jewel/SceneDelegate.swift
@@ -32,6 +32,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             self.window = window
             window.makeKeyAndVisible()
         }
+        
+        //  Handle the incoming Universal Link from cold
+        if let userActivity = connectionOptions.userActivities.first {
+            self.scene(scene, continue: userActivity)
+        }
+    }
+    
+    // Handle the incoming Universal Link from warm
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+            let urlToOpen = userActivity.webpageURL else {
+                return
+                
+        }
+        userData.processSharedCollection(sharedCollectionUrl: urlToOpen)
+        
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Jewel/SceneDelegate.swift
+++ b/Jewel/SceneDelegate.swift
@@ -46,7 +46,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 return
                 
         }
-        userData.processSharedCollection(sharedCollectionUrl: urlToOpen)
+        userData.processRecievedCollection(recievedCollectionUrl: urlToOpen)
         
     }
 

--- a/Jewel/Views/AlbumDetailCompact.swift
+++ b/Jewel/Views/AlbumDetailCompact.swift
@@ -21,7 +21,7 @@ struct AlbumDetailCompact: View {
             AlbumCover(slotIndex: slotIndex)
             PlaybackLinks(slotIndex: slotIndex)
                 .padding(.bottom)
-            IfLet(userData.collection.slots[slotIndex].source?.album) { album in
+            IfLet(userData.activeCollection.slots[slotIndex].source?.album) { album in
                 AlbumTrackList(slotIndex: self.slotIndex)
             }
         }

--- a/Jewel/Views/AlbumDetailRegular.swift
+++ b/Jewel/Views/AlbumDetailRegular.swift
@@ -21,12 +21,12 @@ struct AlbumDetailRegular: View {
                 AlbumCover(slotIndex: slotIndex)
                 PlaybackLinks(slotIndex: slotIndex)
                     .padding(.bottom)
-                IfLet(userData.collection.slots[slotIndex].source?.album?.attributes?.editorialNotes?.standard) { notes in
+                IfLet(userData.activeCollection.slots[slotIndex].source?.album?.attributes?.editorialNotes?.standard) { notes in
                     Text(notes)
                 }
             }
             VStack {
-                IfLet(userData.collection.slots[slotIndex].source?.album) { album in
+                IfLet(userData.activeCollection.slots[slotIndex].source?.album) { album in
                     AlbumTrackList(slotIndex: self.slotIndex)
                 }.padding(.horizontal)
                 Spacer()

--- a/Jewel/Views/Components/AdditionalPlaybackLinks.swift
+++ b/Jewel/Views/Components/AdditionalPlaybackLinks.swift
@@ -30,7 +30,7 @@ struct AdditionalPlaybackLinks: View {
                                     Group {
                                         if platform.iconRef != nil {
                                             Text(verbatim: platform.iconRef!)
-                                            .font(.custom("FontAwesome5Brands-Regular", size: 16))
+                                                .font(.custom("FontAwesome5Brands-Regular", size: 16))
                                         } else {
                                             Image(systemName: "arrowshape.turn.up.right")
                                         }
@@ -38,7 +38,7 @@ struct AdditionalPlaybackLinks: View {
                                     .frame(width: 40, alignment: .center)
                                     .foregroundColor(.secondary)
                                     Text(platform.friendlyName)
-                                    .foregroundColor(.primary)
+                                        .foregroundColor(.primary)
                                 }
                             }
                         }
@@ -47,8 +47,8 @@ struct AdditionalPlaybackLinks: View {
                         UIApplication.shared.open(URL(string: "https://odesli.co")!)
                     }) {
                         Text("Platform links powered by Songlink")
-                        .foregroundColor(.secondary)
-                        .font(.footnote)
+                            .foregroundColor(.secondary)
+                            .font(.footnote)
                     }.padding(.vertical)
                 }
                 .navigationBarTitle("Play in ...", displayMode: .inline)

--- a/Jewel/Views/Components/AdditionalPlaybackLinks.swift
+++ b/Jewel/Views/Components/AdditionalPlaybackLinks.swift
@@ -16,13 +16,13 @@ struct AdditionalPlaybackLinks: View {
     
     var body: some View {
         
-        let availablePlatforms = OdesliPlatform.allCases.filter { userData.collection.slots[slotIndex].playbackLinks?.linksByPlatform[$0.rawValue] != nil }
+        let availablePlatforms = OdesliPlatform.allCases.filter { userData.activeCollection.slots[slotIndex].playbackLinks?.linksByPlatform[$0.rawValue] != nil }
         
         let additionalPlaybackLinksView =
             NavigationView {
                 VStack {
                     List(availablePlatforms, id: \.self) { platform in
-                        IfLet(self.userData.collection.slots[self.slotIndex].playbackLinks?.linksByPlatform[platform.rawValue]) { platformLink in
+                        IfLet(self.userData.activeCollection.slots[self.slotIndex].playbackLinks?.linksByPlatform[platform.rawValue]) { platformLink in
                             Button(action: {
                                 UIApplication.shared.open(platformLink.url)
                             }) {

--- a/Jewel/Views/Components/AlbumCard.swift
+++ b/Jewel/Views/Components/AlbumCard.swift
@@ -20,7 +20,7 @@ struct AlbumCard: View {
         Rectangle()
         .foregroundColor(.clear)
         .background(
-            IfLet(userData.collection.slots[slotIndex].source?.album?.attributes?.artwork) { artwork in
+            IfLet(userData.activeCollection.slots[slotIndex].source?.album?.attributes?.artwork) { artwork in
                 KFImage(artwork.url(forWidth: 1000))
                 .placeholder {
                     RoundedRectangle(cornerRadius: 4)
@@ -33,7 +33,7 @@ struct AlbumCard: View {
         .cornerRadius(4)
         .overlay(
             VStack(alignment: .leading) {
-                IfLet(userData.collection.slots[slotIndex].source?.album?.attributes) { attributes in
+                IfLet(userData.activeCollection.slots[slotIndex].source?.album?.attributes) { attributes in
                     Text(attributes.name)
                         .font(.callout)
                         .fontWeight(.bold)

--- a/Jewel/Views/Components/AlbumCard.swift
+++ b/Jewel/Views/Components/AlbumCard.swift
@@ -18,42 +18,42 @@ struct AlbumCard: View {
     var body: some View {
         
         Rectangle()
-        .foregroundColor(.clear)
-        .background(
-            IfLet(userData.activeCollection.slots[slotIndex].source?.album?.attributes?.artwork) { artwork in
-                KFImage(artwork.url(forWidth: 1000))
-                .placeholder {
-                    RoundedRectangle(cornerRadius: 4)
-                    .fill(Color.gray)
-                }
-                .renderingMode(.original)
-                .resizable()
-                .scaledToFill()
+            .foregroundColor(.clear)
+            .background(
+                IfLet(userData.activeCollection.slots[slotIndex].source?.album?.attributes?.artwork) { artwork in
+                    KFImage(artwork.url(forWidth: 1000))
+                        .placeholder {
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Color.gray)
+                    }
+                    .renderingMode(.original)
+                    .resizable()
+                    .scaledToFill()
             })
-        .cornerRadius(4)
-        .overlay(
-            VStack(alignment: .leading) {
-                IfLet(userData.activeCollection.slots[slotIndex].source?.album?.attributes) { attributes in
-                    Text(attributes.name)
-                        .font(.callout)
-                        .fontWeight(.bold)
-                        .foregroundColor(.white)
-                        .padding(.top, 4)
-                        .padding(.horizontal, 6)
-                        .lineLimit(1)
-                    Text(attributes.artistName)
-                        .font(.footnote)
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 6)
-                        .padding(.bottom, 4)
-                        .lineLimit(1)
-                }
-            }
-            .background(Color.black)
             .cornerRadius(4)
-            .padding(4)
-        , alignment: .bottomLeading)
-        .shadow(radius: 3)
+            .overlay(
+                VStack(alignment: .leading) {
+                    IfLet(userData.activeCollection.slots[slotIndex].source?.album?.attributes) { attributes in
+                        Text(attributes.name)
+                            .font(.callout)
+                            .fontWeight(.bold)
+                            .foregroundColor(.white)
+                            .padding(.top, 4)
+                            .padding(.horizontal, 6)
+                            .lineLimit(1)
+                        Text(attributes.artistName)
+                            .font(.footnote)
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 6)
+                            .padding(.bottom, 4)
+                            .lineLimit(1)
+                    }
+                }
+                .background(Color.black)
+                .cornerRadius(4)
+                .padding(4)
+                , alignment: .bottomLeading)
+            .shadow(radius: 3)
     }
 }
 

--- a/Jewel/Views/Components/AlbumCover.swift
+++ b/Jewel/Views/Components/AlbumCover.swift
@@ -21,11 +21,11 @@ struct AlbumCover: View {
                     .placeholder {
                         RoundedRectangle(cornerRadius: 4)
                             .fill(Color.gray)
-                    }
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .cornerRadius(4)
-                    .shadow(radius: 4)
+                }
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .cornerRadius(4)
+                .shadow(radius: 4)
                 Group {
                     Text(attributes.name)
                         .fontWeight(.bold)

--- a/Jewel/Views/Components/AlbumCover.swift
+++ b/Jewel/Views/Components/AlbumCover.swift
@@ -16,7 +16,7 @@ struct AlbumCover: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            IfLet(userData.collection.slots[slotIndex].source?.album?.attributes) { attributes in
+            IfLet(userData.activeCollection.slots[slotIndex].source?.album?.attributes) { attributes in
                 KFImage(attributes.artwork.url(forWidth: 1000))
                     .placeholder {
                         RoundedRectangle(cornerRadius: 4)

--- a/Jewel/Views/Components/AlbumTrackList.swift
+++ b/Jewel/Views/Components/AlbumTrackList.swift
@@ -15,7 +15,7 @@ struct AlbumTrackList: View {
     
     var body: some View {
         
-        let tracks = userData.collection.slots[slotIndex].source?.album?.relationships?.tracks.data
+        let tracks = userData.activeCollection.slots[slotIndex].source?.album?.relationships?.tracks.data
         let discCount = tracks?.map { $0.attributes?.discNumber ?? 1 }.max()
         
         let albumTrackList = VStack(alignment: .leading) {

--- a/Jewel/Views/Components/DiscTrackList.swift
+++ b/Jewel/Views/Components/DiscTrackList.swift
@@ -16,7 +16,7 @@ struct DiscTrackList: View {
     var withTitle: Bool
     
     var body: some View {
-
+        
         let tracks = userData.activeCollection.slots[slotIndex].source?.album?.relationships?.tracks.data
         let discTracks = tracks?.filter { $0.attributes?.discNumber == discNumber }
         let albumArtist = userData.activeCollection.slots[slotIndex].source?.album?.attributes?.artistName
@@ -52,8 +52,8 @@ struct DiscTrackList: View {
                             Spacer()
                             IfLet(attributes.duration) { duration in
                                 Text(duration)
-                                .font(.footnote)
-                                .opacity(0.7)
+                                    .font(.footnote)
+                                    .opacity(0.7)
                             }
                         }
                     }

--- a/Jewel/Views/Components/DiscTrackList.swift
+++ b/Jewel/Views/Components/DiscTrackList.swift
@@ -17,9 +17,9 @@ struct DiscTrackList: View {
     
     var body: some View {
 
-        let tracks = userData.collection.slots[slotIndex].source?.album?.relationships?.tracks.data
+        let tracks = userData.activeCollection.slots[slotIndex].source?.album?.relationships?.tracks.data
         let discTracks = tracks?.filter { $0.attributes?.discNumber == discNumber }
-        let albumArtist = userData.collection.slots[slotIndex].source?.album?.attributes?.artistName
+        let albumArtist = userData.activeCollection.slots[slotIndex].source?.album?.attributes?.artistName
         
         let discTrackList = VStack(alignment: .leading) {
             if withTitle {

--- a/Jewel/Views/Components/IfLet.swift
+++ b/Jewel/Views/Components/IfLet.swift
@@ -11,13 +11,13 @@ import SwiftUI
 struct IfLet<Value, Content: View>: View {
     private let value: Value?
     private let contentProvider: (Value) -> Content
-
+    
     init(_ value: Value?,
          @ViewBuilder content: @escaping (Value) -> Content) {
         self.value = value
         self.contentProvider = content
     }
-
+    
     var body: some View {
         value.map(contentProvider)
     }

--- a/Jewel/Views/Components/PlaybackLinks.swift
+++ b/Jewel/Views/Components/PlaybackLinks.swift
@@ -16,10 +16,10 @@ struct PlaybackLinks: View {
     @State private var showAdditionalLinks = false
     
     var body: some View {
-        IfLet(userData.collection.slots[slotIndex].source?.album?.attributes?.url) { url in
+        IfLet(userData.activeCollection.slots[slotIndex].source?.album?.attributes?.url) { url in
             ZStack {
                 PrimaryPlaybackLink(slotIndex: self.slotIndex)
-                if self.userData.collection.slots[self.slotIndex].playbackLinks != nil {
+                if self.userData.activeCollection.slots[self.slotIndex].playbackLinks != nil {
                     HStack {
                         Spacer()
                         Button(action: {

--- a/Jewel/Views/Components/PrimaryPlaybackLink.swift
+++ b/Jewel/Views/Components/PrimaryPlaybackLink.swift
@@ -20,11 +20,11 @@ struct PrimaryPlaybackLink: View {
         
         let preferredProvider = OdesliPlatform.allCases[userData.prefs.preferredMusicPlatform]
         
-        if let providerLink = userData.collection.slots[slotIndex].playbackLinks?.linksByPlatform[preferredProvider.rawValue] {
+        if let providerLink = userData.activeCollection.slots[slotIndex].playbackLinks?.linksByPlatform[preferredProvider.rawValue] {
             playbackLink = providerLink.url
             playbackName = preferredProvider.friendlyName
         } else {
-            playbackLink = userData.collection.slots[slotIndex].source?.album?.attributes?.url
+            playbackLink = userData.activeCollection.slots[slotIndex].source?.album?.attributes?.url
             playbackName = OdesliPlatform.appleMusic.friendlyName
         }
             

--- a/Jewel/Views/Components/PrimaryPlaybackLink.swift
+++ b/Jewel/Views/Components/PrimaryPlaybackLink.swift
@@ -27,7 +27,7 @@ struct PrimaryPlaybackLink: View {
             playbackLink = userData.activeCollection.slots[slotIndex].source?.album?.attributes?.url
             playbackName = OdesliPlatform.appleMusic.friendlyName
         }
-            
+        
         let playbackLinkView =
             IfLet(playbackLink) { url in
                 Button(action: {
@@ -47,7 +47,7 @@ struct PrimaryPlaybackLink: View {
                             .stroke(Color.primary, lineWidth: 2)
                     )
                 }
-            }
+        }
         
         return playbackLinkView
     }
@@ -60,5 +60,5 @@ struct PlaybackLink_Previews: PreviewProvider {
     static var previews: some View {
         PrimaryPlaybackLink(slotIndex: 0).environmentObject(userData)
     }
-
+    
 }

--- a/Jewel/Views/Components/ShareSheet.swift
+++ b/Jewel/Views/Components/ShareSheet.swift
@@ -10,12 +10,12 @@ import SwiftUI
 
 struct ShareSheet: UIViewControllerRepresentable {
     typealias Callback = (_ activityType: UIActivity.ActivityType?, _ completed: Bool, _ returnedItems: [Any]?, _ error: Error?) -> Void
-      
+    
     let activityItems: [Any]
     let applicationActivities: [UIActivity]? = nil
     let excludedActivityTypes: [UIActivity.ActivityType]? = nil
     let callback: Callback? = nil
-      
+    
     func makeUIViewController(context: Context) -> UIActivityViewController {
         
         let controller = UIActivityViewController(
@@ -25,7 +25,7 @@ struct ShareSheet: UIViewControllerRepresentable {
         controller.completionWithItemsHandler = callback
         return controller
     }
-      
+    
     func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
         // nothing to do here
     }

--- a/Jewel/Views/Components/ShareSheet.swift
+++ b/Jewel/Views/Components/ShareSheet.swift
@@ -1,0 +1,32 @@
+//
+//  ShareSheet.swift
+//  Jewel
+//
+//  Created by Greg Hepworth on 15/05/2020.
+//  Copyright © 2020 Breakbeat Ltd. All rights reserved.
+//
+
+import SwiftUI
+
+struct ShareSheet: UIViewControllerRepresentable {
+    typealias Callback = (_ activityType: UIActivity.ActivityType?, _ completed: Bool, _ returnedItems: [Any]?, _ error: Error?) -> Void
+      
+    let activityItems: [Any]
+    let applicationActivities: [UIActivity]? = nil
+    let excludedActivityTypes: [UIActivity.ActivityType]? = nil
+    let callback: Callback? = nil
+      
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        
+        let controller = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: applicationActivities)
+        controller.excludedActivityTypes = excludedActivityTypes
+        controller.completionWithItemsHandler = callback
+        return controller
+    }
+      
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+        // nothing to do here
+    }
+}  

--- a/Jewel/Views/EmptySlot.swift
+++ b/Jewel/Views/EmptySlot.swift
@@ -16,25 +16,31 @@ struct EmptySlot: View {
     @State private var showSearch = false
     
     var body: some View {
-        
-        Button(action: {
-            self.showSearch = true
-        }) {
-            RoundedRectangle(cornerRadius: 4)
-            .stroke(
-                Color.gray,
-                style: StrokeStyle(lineWidth: 2, dash: [4, 6])
-            )
-            .overlay(
-                Image(systemName: "plus")
-                    .font(.headline)
-                    .foregroundColor(Color.gray)
-            )
-        }
-        .sheet(isPresented: $showSearch) {
-            Search(slotIndex: self.slotIndex)
-                .environmentObject(self.userData)
-                .environmentObject(self.searchProvider)
+        HStack {
+            if userData.activeCollection.editable {
+                Button(action: {
+                    self.showSearch = true
+                }) {
+                    RoundedRectangle(cornerRadius: 4)
+                    .stroke(
+                        Color.gray,
+                        style: StrokeStyle(lineWidth: 2, dash: [4, 6])
+                    )
+                    .overlay(
+                        Image(systemName: "plus")
+                            .font(.headline)
+                            .foregroundColor(Color.gray)
+                    )
+                }
+                .sheet(isPresented: $showSearch) {
+                    Search(slotIndex: self.slotIndex)
+                        .environmentObject(self.userData)
+                        .environmentObject(self.searchProvider)
+                }
+            } else {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray)
+            }
         }
     }
 }

--- a/Jewel/Views/EmptySlot.swift
+++ b/Jewel/Views/EmptySlot.swift
@@ -22,14 +22,14 @@ struct EmptySlot: View {
                     self.showSearch = true
                 }) {
                     RoundedRectangle(cornerRadius: 4)
-                    .stroke(
-                        Color.gray,
-                        style: StrokeStyle(lineWidth: 2, dash: [4, 6])
+                        .stroke(
+                            Color.gray,
+                            style: StrokeStyle(lineWidth: 2, dash: [4, 6])
                     )
-                    .overlay(
-                        Image(systemName: "plus")
-                            .font(.headline)
-                            .foregroundColor(Color.gray)
+                        .overlay(
+                            Image(systemName: "plus")
+                                .font(.headline)
+                                .foregroundColor(Color.gray)
                     )
                 }
                 .sheet(isPresented: $showSearch) {

--- a/Jewel/Views/FilledSlot.swift
+++ b/Jewel/Views/FilledSlot.swift
@@ -24,7 +24,9 @@ struct FilledSlot: View {
                 self.tapped = 1
             }
             .onLongPressGesture() {
-                self.showSearch = true
+                if self.userData.activeCollection.editable {
+                    self.showSearch = true
+                }
             }
             NavigationLink(
                 destination: SlotDetail(slotIndex: self.slotIndex),

--- a/Jewel/Views/FilledSlot.swift
+++ b/Jewel/Views/FilledSlot.swift
@@ -20,8 +20,8 @@ struct FilledSlot: View {
         
         ZStack {
             AlbumCard(slotIndex: self.slotIndex)
-            .onTapGesture {
-                self.tapped = 1
+                .onTapGesture {
+                    self.tapped = 1
             }
             .onLongPressGesture() {
                 if self.userData.activeCollection.editable {

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -12,6 +12,7 @@ struct Home: View {
     
     @EnvironmentObject var userData: UserData
     @State private var showOptions = false
+    @State private var showShareSheet = false
     
     private func slotViewForId(slotIndex: Int) -> some View {
         if userData.activeCollection.slots[slotIndex].source?.album == nil {
@@ -45,15 +46,15 @@ struct Home: View {
                     }
                     ,trailing:
                     HStack {
-//                        Button(action: {
-//                            self.showShareSheet = true
-//                        }) {
-//                            Image(systemName: "square.and.arrow.up")
-//                                .padding()
-//                        }
-//                        .sheet(isPresented: self.$showShareSheet) {
-//                            ShareSheet(activityItems: [self.userData.createShareUrl()])
-//                        }
+                        Button(action: {
+                            self.showShareSheet = true
+                        }) {
+                            Image(systemName: "square.and.arrow.up")
+                                .padding()
+                        }
+                        .sheet(isPresented: self.$showShareSheet) {
+                            ShareSheet(activityItems: [self.userData.createShareUrl()])
+                        }
                         Button(action: {
                             self.userData.switchActiveCollection()
                         }) {

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -36,12 +36,30 @@ struct Home: View {
                     UITableView.appearance().separatorStyle = .none
                 }
                 .navigationBarTitle(self.userData.activeCollection.name)
-                .navigationBarItems(trailing:
+                .navigationBarItems(leading:
                     Button(action: {
                         self.showOptions = true
                     }) {
                         Image(systemName: "slider.horizontal.3")
                             .padding()
+                    }
+                    ,trailing:
+                    HStack {
+//                        Button(action: {
+//                            self.showShareSheet = true
+//                        }) {
+//                            Image(systemName: "square.and.arrow.up")
+//                                .padding()
+//                        }
+//                        .sheet(isPresented: self.$showShareSheet) {
+//                            ShareSheet(activityItems: [self.userData.createShareUrl()])
+//                        }
+                        Button(action: {
+                            self.userData.switchActiveCollection()
+                        }) {
+                            Image(systemName: "arrow.2.squarepath")
+                                .padding()
+                        }
                     }
                 )
             }

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -55,6 +55,7 @@ struct Home: View {
                         }
                         .padding(.leading)
                         .padding(.vertical)
+                        .disabled(self.userData.activeCollection.slots.filter( { $0.source != nil }).count == 0)
                         .sheet(isPresented: self.$showShareSheet) {
                             ShareSheet(activityItems: [self.userData.createShareUrl()])
                         }

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -70,9 +70,9 @@ struct Home: View {
             }
             .alert(isPresented: $userData.sharedCollectionCued) {
                 Alert(title: Text("Shared collection received from \(userData.candidateCollection?.curator ?? "another music lover")!"),
-                      message: Text("Would you like to replace your current shared collection?"),
-                      primaryButton: .cancel(Text("Cancel")),
-                      secondaryButton: .default(Text("Replace").bold()) {
+                    message: Text("Would you like to replace your current shared collection?"),
+                    primaryButton: .cancel(Text("Cancel")),
+                    secondaryButton: .default(Text("Replace").bold()) {
                         self.userData.loadCandidateCollection()
                         self.presentationMode.wrappedValue.dismiss()
                     })

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -14,7 +14,7 @@ struct Home: View {
     @State private var showOptions = false
     
     private func slotViewForId(slotIndex: Int) -> some View {
-        if userData.collection.slots[slotIndex].source?.album == nil {
+        if userData.activeCollection.slots[slotIndex].source?.album == nil {
             return AnyView(EmptySlot(slotIndex: slotIndex))
         } else {
             return AnyView(FilledSlot(slotIndex: slotIndex))
@@ -25,9 +25,9 @@ struct Home: View {
         
         NavigationView {
             GeometryReader { geo in
-                List(self.userData.collection.slots.indices, id: \.self) { index in
+                List(self.userData.activeCollection.slots.indices, id: \.self) { index in
                     self.slotViewForId(slotIndex: index)
-                        .frame(height: (geo.size.height - geo.safeAreaInsets.top - geo.safeAreaInsets.bottom) / CGFloat(self.userData.collection.slots.count))
+                        .frame(height: (geo.size.height - geo.safeAreaInsets.top - geo.safeAreaInsets.bottom) / CGFloat(self.userData.activeCollection.slots.count))
                 }
                 .sheet(isPresented: self.$showOptions) {
                     Options().environmentObject(self.userData)
@@ -35,7 +35,7 @@ struct Home: View {
                 .onAppear {
                     UITableView.appearance().separatorStyle = .none
                 }
-                .navigationBarTitle(self.userData.collection.name)
+                .navigationBarTitle(self.userData.activeCollection.name)
                 .navigationBarItems(trailing:
                     Button(action: {
                         self.showOptions = true

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -72,9 +72,9 @@ struct Home: View {
             }
             .alert(isPresented: $userData.sharedCollectionCued) {
                 Alert(title: Text("Shared collection received from \(userData.candidateCollection?.curator ?? "another music lover")!"),
-                    message: Text("Would you like to replace your current shared collection?"),
-                    primaryButton: .cancel(Text("Cancel")),
-                    secondaryButton: .default(Text("Replace").bold()) {
+                      message: Text("Would you like to replace your current shared collection?"),
+                      primaryButton: .cancel(Text("Cancel")),
+                      secondaryButton: .default(Text("Replace").bold()) {
                         self.userData.loadCandidateCollection()
                         self.presentationMode.wrappedValue.dismiss()
                     })

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -43,16 +43,18 @@ struct Home: View {
                         self.showOptions = true
                     }) {
                         Image(systemName: "slider.horizontal.3")
-                            .padding()
                     }
+                    .padding(.trailing)
+                    .padding(.vertical)
                     ,trailing:
                     HStack {
                         Button(action: {
                             self.showShareSheet = true
                         }) {
                             Image(systemName: "square.and.arrow.up")
-                                .padding()
                         }
+                        .padding(.leading)
+                        .padding(.vertical)
                         .sheet(isPresented: self.$showShareSheet) {
                             ShareSheet(activityItems: [self.userData.createShareUrl()])
                         }
@@ -60,8 +62,9 @@ struct Home: View {
                             self.userData.userCollectionActive.toggle()
                         }) {
                             Image(systemName: "arrow.2.squarepath")
-                                .padding()
                         }
+                        .padding(.leading)
+                        .padding(.vertical)
                     }
                 )
             }

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct Home: View {
     
+    @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var userData: UserData
     @State private var showOptions = false
     @State private var showShareSheet = false
@@ -63,6 +64,15 @@ struct Home: View {
                         }
                     }
                 )
+            }
+            .alert(isPresented: $userData.sharedCollectionCued) {
+                Alert(title: Text("Shared collection received!"),
+                      message: Text("Would you like to replace your current shared collection?"),
+                      primaryButton: .cancel(Text("Cancel")),
+                      secondaryButton: .default(Text("Replace").bold()) {
+                        self.userData.loadCandidateCollection()
+                        self.presentationMode.wrappedValue.dismiss()
+                    })
             }
             Start()
         }

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -57,7 +57,7 @@ struct Home: View {
                             ShareSheet(activityItems: [self.userData.createShareUrl()])
                         }
                         Button(action: {
-                            self.userData.switchActiveCollection()
+                            self.userData.userCollectionActive.toggle()
                         }) {
                             Image(systemName: "arrow.2.squarepath")
                                 .padding()

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -65,6 +65,7 @@ struct Home: View {
                         }
                         .padding(.leading)
                         .padding(.vertical)
+                        .disabled(self.userData.sharedCollection.slots.filter( { $0.source != nil }).count == 0)
                     }
                 )
             }

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -66,7 +66,7 @@ struct Home: View {
                 )
             }
             .alert(isPresented: $userData.sharedCollectionCued) {
-                Alert(title: Text("Shared collection received!"),
+                Alert(title: Text("Shared collection received from \(userData.candidateCollection?.curator ?? "another music lover")!"),
                       message: Text("Would you like to replace your current shared collection?"),
                       primaryButton: .cancel(Text("Cancel")),
                       secondaryButton: .default(Text("Replace").bold()) {

--- a/Jewel/Views/Options/Options.swift
+++ b/Jewel/Views/Options/Options.swift
@@ -20,32 +20,30 @@ struct Options: View {
         NavigationView {
             VStack {
                 Form {
-                    Section {
+                    Section(footer: Text("Choose a name for your collection, and to represent the curator when sharing the collection.")) {
                         HStack(alignment: .firstTextBaseline) {
-                            Text("My Collection Name")
+                            Text("Collection Name")
                             TextField(
                                 userData.userCollection.name,
                                 text: $userData.userCollection.name,
                                 onCommit: {
                                     self.presentationMode.wrappedValue.dismiss()
                             }
-                            ).foregroundColor(.blue)
+                            ).foregroundColor(.accentColor)
                         }
-                    }
-                    Section(footer: Text("Choose a name to represent the curator when sharing the collection.")) {
                         HStack(alignment: .firstTextBaseline) {
-                            Text("Curator Name")
+                            Text("Curator")
                             TextField(
-                                userData.prefs.curatorName,
-                                text: $userData.prefs.curatorName,
+                                userData.userCollection.curator,
+                                text: $userData.userCollection.curator,
                                 onCommit: {
                                     self.presentationMode.wrappedValue.dismiss()
                             }
-                            ).foregroundColor(.blue)
+                            ).foregroundColor(.accentColor)
                         }
                     }
                     Section(footer: Text("If available, use this service for playback, otherwise use Apple Music.")) {
-                        Picker(selection: $userData.prefs.preferredMusicPlatform, label: Text("Preferred Playback Service")) {
+                        Picker(selection: $userData.prefs.preferredMusicPlatform, label: Text("Playback Service")) {
                             ForEach(0 ..< OdesliPlatform.allCases.count, id: \.self) {
                                 Text(OdesliPlatform.allCases[$0].friendlyName)
                             }
@@ -67,35 +65,37 @@ struct Options: View {
                                 })
                         }
                     }
-                    Button(action: {
-                        self.showEjectMyCollectionWarning = true
-                    }) {
-                        Text("Eject My Collection")
-                    }
-                    .foregroundColor(.red)
-                    .alert(isPresented: $showEjectMyCollectionWarning) {
-                        Alert(title: Text("Are you sure you want to eject all the albums in your collection?"),
-                              message: Text("You cannot undo this operation."),
-                              primaryButton: .cancel(Text("Cancel")),
-                              secondaryButton: .destructive(Text("Eject All")) {
-                                self.userData.ejectUserCollection()
-                                self.presentationMode.wrappedValue.dismiss()
-                            })
-                    }
-                    Button(action: {
-                        self.showEjectSharedCollectionWarning = true
-                    }) {
-                        Text("Eject Shared Collection")
-                    }
-                    .foregroundColor(.red)
-                    .alert(isPresented: $showEjectSharedCollectionWarning) {
-                        Alert(title: Text("Are you sure you want to eject your current shared collection?"),
-                              message: Text("You cannot undo this operation."),
-                              primaryButton: .cancel(Text("Cancel")),
-                              secondaryButton: .destructive(Text("Eject Shared")) {
-                                self.userData.ejectSharedCollection()
-                                self.presentationMode.wrappedValue.dismiss()
-                            })
+                    Section(header: Text("SYSTEM")) {
+                        Button(action: {
+                            self.showEjectMyCollectionWarning = true
+                        }) {
+                            Text("Eject My Collection")
+                        }
+                        .foregroundColor(.red)
+                        .alert(isPresented: $showEjectMyCollectionWarning) {
+                            Alert(title: Text("Are you sure you want to eject all the albums in your collection?"),
+                                  message: Text("You cannot undo this operation."),
+                                  primaryButton: .cancel(Text("Cancel")),
+                                  secondaryButton: .destructive(Text("Eject All")) {
+                                    self.userData.ejectUserCollection()
+                                    self.presentationMode.wrappedValue.dismiss()
+                                })
+                        }
+                        Button(action: {
+                            self.showEjectSharedCollectionWarning = true
+                        }) {
+                            Text("Eject Shared Collection")
+                        }
+                        .foregroundColor(.red)
+                        .alert(isPresented: $showEjectSharedCollectionWarning) {
+                            Alert(title: Text("Are you sure you want to eject your current shared collection?"),
+                                  message: Text("You cannot undo this operation."),
+                                  primaryButton: .cancel(Text("Cancel")),
+                                  secondaryButton: .destructive(Text("Eject Shared")) {
+                                    self.userData.ejectSharedCollection()
+                                    self.presentationMode.wrappedValue.dismiss()
+                                })
+                        }
                     }
                     if userData.prefs.debugMode {
                         Section(header: Text("Debug")) {

--- a/Jewel/Views/Options/Options.swift
+++ b/Jewel/Views/Options/Options.swift
@@ -23,8 +23,8 @@ struct Options: View {
                         HStack(alignment: .firstTextBaseline) {
                             Text("My Collection Name")
                             TextField(
-                                userData.activeCollection.name,
-                                text: $userData.activeCollection.name,
+                                userData.userCollection.name,
+                                text: $userData.userCollection.name,
                                 onCommit: {
                                     self.presentationMode.wrappedValue.dismiss()
                                 }

--- a/Jewel/Views/Options/Options.swift
+++ b/Jewel/Views/Options/Options.swift
@@ -21,10 +21,22 @@ struct Options: View {
                 Form {
                     Section {
                         HStack(alignment: .firstTextBaseline) {
-                            Text("Collection Name")
+                            Text("My Collection Name")
                             TextField(
                                 userData.collection.name,
                                 text: $userData.collection.name,
+                                onCommit: {
+                                    self.presentationMode.wrappedValue.dismiss()
+                                }
+                            ).foregroundColor(.blue)
+                        }
+                    }
+                    Section(footer: Text("Choose a name to represent the curator when sharing the collection.")) {
+                        HStack(alignment: .firstTextBaseline) {
+                            Text("Curator Name")
+                            TextField(
+                                userData.prefs.curatorName,
+                                text: $userData.prefs.curatorName,
                                 onCommit: {
                                     self.presentationMode.wrappedValue.dismiss()
                                 }

--- a/Jewel/Views/Options/Options.swift
+++ b/Jewel/Views/Options/Options.swift
@@ -58,7 +58,7 @@ struct Options: View {
                         }
                         .alert(isPresented: $showLoadRecommendationsAlert) {
                             Alert(title: Text("Are you sure you want to load our recommendations?"),
-                                  message: Text("This will remove your current collection."),
+                                  message: Text("This will replace your current shared collection."),
                                   primaryButton: .cancel(Text("Cancel")),
                                   secondaryButton: .default(Text("Load").bold()) {
                                     self.userData.loadRecommendations()

--- a/Jewel/Views/Options/Options.swift
+++ b/Jewel/Views/Options/Options.swift
@@ -27,7 +27,7 @@ struct Options: View {
                                 text: $userData.userCollection.name,
                                 onCommit: {
                                     self.presentationMode.wrappedValue.dismiss()
-                                }
+                            }
                             ).foregroundColor(.blue)
                         }
                     }
@@ -39,7 +39,7 @@ struct Options: View {
                                 text: $userData.prefs.curatorName,
                                 onCommit: {
                                     self.presentationMode.wrappedValue.dismiss()
-                                }
+                            }
                             ).foregroundColor(.blue)
                         }
                     }
@@ -94,7 +94,7 @@ struct Options: View {
                                 self.presentationMode.wrappedValue.dismiss()
                             }) {
                                 Text("Reset Jewel")
-                                .foregroundColor(.red)
+                                    .foregroundColor(.red)
                             }
                         }
                     }
@@ -103,7 +103,7 @@ struct Options: View {
                 Footer()
                     .onTapGesture(count: 10) {
                         self.userData.prefs.debugMode.toggle()
-                    }
+                }
                 .padding()
             }
             .navigationBarTitle("Options", displayMode: .inline)

--- a/Jewel/Views/Options/Options.swift
+++ b/Jewel/Views/Options/Options.swift
@@ -12,7 +12,6 @@ struct Options: View {
     
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var userData: UserData
-    @State private var newCollectionName = ""
     @State private var showDeleteAllWarning = false
     @State private var showLoadRecommendationsAlert = false
     
@@ -25,9 +24,8 @@ struct Options: View {
                             Text("Collection Name")
                             TextField(
                                 userData.collection.name,
-                                text: $newCollectionName,
+                                text: $userData.collection.name,
                                 onCommit: {
-                                    self.userData.collection.name = self.newCollectionName
                                     self.presentationMode.wrappedValue.dismiss()
                                 }
                             ).foregroundColor(.blue)
@@ -106,6 +104,10 @@ struct Options: View {
             )
         }
         .navigationViewStyle(StackNavigationViewStyle())
+        .onDisappear {
+            self.userData.collectionChanged()
+            self.userData.preferencesChanged()
+        }
     }
 }
 

--- a/Jewel/Views/Options/Options.swift
+++ b/Jewel/Views/Options/Options.swift
@@ -61,7 +61,7 @@ struct Options: View {
                                   message: Text("This will replace your current shared collection."),
                                   primaryButton: .cancel(Text("Cancel")),
                                   secondaryButton: .default(Text("Load").bold()) {
-                                    self.userData.loadRecommendations()
+                                    self.userData.getRecommendations()
                                     self.presentationMode.wrappedValue.dismiss()
                                 })
                         }

--- a/Jewel/Views/Options/Options.swift
+++ b/Jewel/Views/Options/Options.swift
@@ -12,7 +12,8 @@ struct Options: View {
     
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var userData: UserData
-    @State private var showDeleteAllWarning = false
+    @State private var showEjectMyCollectionWarning = false
+    @State private var showEjectSharedCollectionWarning = false
     @State private var showLoadRecommendationsAlert = false
     
     var body: some View {
@@ -67,17 +68,32 @@ struct Options: View {
                         }
                     }
                     Button(action: {
-                        self.showDeleteAllWarning = true
+                        self.showEjectMyCollectionWarning = true
                     }) {
-                        Text("Delete All")
+                        Text("Eject My Collection")
                     }
                     .foregroundColor(.red)
-                    .alert(isPresented: $showDeleteAllWarning) {
-                        Alert(title: Text("Are you sure you want to delete all albums in your collection?"),
+                    .alert(isPresented: $showEjectMyCollectionWarning) {
+                        Alert(title: Text("Are you sure you want to eject all the albums in your collection?"),
                               message: Text("You cannot undo this operation."),
                               primaryButton: .cancel(Text("Cancel")),
-                              secondaryButton: .destructive(Text("Delete")) {
-                                self.userData.deleteAll()
+                              secondaryButton: .destructive(Text("Eject All")) {
+                                self.userData.ejectUserCollection()
+                                self.presentationMode.wrappedValue.dismiss()
+                            })
+                    }
+                    Button(action: {
+                        self.showEjectSharedCollectionWarning = true
+                    }) {
+                        Text("Eject Shared Collection")
+                    }
+                    .foregroundColor(.red)
+                    .alert(isPresented: $showEjectSharedCollectionWarning) {
+                        Alert(title: Text("Are you sure you want to eject your current shared collection?"),
+                              message: Text("You cannot undo this operation."),
+                              primaryButton: .cancel(Text("Cancel")),
+                              secondaryButton: .destructive(Text("Eject Shared")) {
+                                self.userData.ejectSharedCollection()
                                 self.presentationMode.wrappedValue.dismiss()
                             })
                     }

--- a/Jewel/Views/Options/Options.swift
+++ b/Jewel/Views/Options/Options.swift
@@ -23,8 +23,8 @@ struct Options: View {
                         HStack(alignment: .firstTextBaseline) {
                             Text("My Collection Name")
                             TextField(
-                                userData.collection.name,
-                                text: $userData.collection.name,
+                                userData.activeCollection.name,
+                                text: $userData.activeCollection.name,
                                 onCommit: {
                                     self.presentationMode.wrappedValue.dismiss()
                                 }

--- a/Jewel/Views/Search/Search.swift
+++ b/Jewel/Views/Search/Search.swift
@@ -15,7 +15,7 @@ struct Search: View {
     @EnvironmentObject var searchProvider: SearchProvider
     @State private var showCancelButton: Bool = false
     var slotIndex: Int
-        
+    
     var body: some View {
         
         VStack(alignment: .leading) {

--- a/Jewel/Views/Search/SearchBar.swift
+++ b/Jewel/Views/Search/SearchBar.swift
@@ -33,9 +33,9 @@ struct SearchBar: View {
                             } else {
                                 self.searchProvider.search(searchTerm: self.searchTerm)
                             }
-                        }
+                    }
                     ).foregroundColor(.primary)
-                    .keyboardType(.webSearch)
+                        .keyboardType(.webSearch)
                     Button(action: {
                         self.searchTerm = ""
                         self.searchProvider.results?.removeAll()

--- a/Jewel/Views/Search/SearchResultsList.swift
+++ b/Jewel/Views/Search/SearchResultsList.swift
@@ -45,7 +45,7 @@ struct SearchResultsList: View {
                         }
                         Spacer()
                         Button(action: {
-                            self.userData.addAlbumToSlot(albumId: albums[i].id, slotIndex: self.slotIndex)
+                            self.userData.addAlbumToSlot(albumId: albums[i].id, collection: self.userData.activeCollection, slotIndex: self.slotIndex)
                             self.presentationMode.wrappedValue.dismiss()
                         }, label:{
                             Image(systemName: "plus.circle")

--- a/Jewel/Views/Search/SearchResultsList.swift
+++ b/Jewel/Views/Search/SearchResultsList.swift
@@ -26,15 +26,15 @@ struct SearchResultsList: View {
                 IfLet(albums[i].attributes) { album in
                     HStack {
                         KFImage(album.artwork.url(forWidth: 50))
-                          .placeholder {
-                              RoundedRectangle(cornerRadius: 4)
-                                  .fill(Color.gray)
-                          }
-                          .renderingMode(.original)
-                          .resizable()
-                          .aspectRatio(contentMode: .fit)
-                          .cornerRadius(4)
-                          .frame(width: 50)
+                            .placeholder {
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(Color.gray)
+                        }
+                        .renderingMode(.original)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .cornerRadius(4)
+                        .frame(width: 50)
                         VStack(alignment: .leading) {
                             Text(album.name)
                                 .font(.headline)

--- a/Jewel/Views/SlotDetail.swift
+++ b/Jewel/Views/SlotDetail.swift
@@ -17,7 +17,7 @@ struct SlotDetail: View {
     @EnvironmentObject var searchProvider: SearchProvider
     var slotIndex: Int
     @State private var showSearch = false
-    @State private var showDeleteWarning = false
+    @State private var showEjectWarning = false
     
     private func slotDetail() -> some View {
         if userData.activeCollection.slots[slotIndex].source?.album != nil {
@@ -44,29 +44,31 @@ struct SlotDetail: View {
         .navigationBarItems(trailing:
             IfLet(userData.activeCollection.slots[slotIndex].source?.album) { album in
                 HStack {
-                    Button(action: {
-                        self.showSearch = true
-                    }) {
-                        Image(systemName: "arrow.swap")
-                    }
-                    .padding(.vertical)
-                    .sheet(isPresented: self.$showSearch) {
-                        Search(slotIndex: self.slotIndex)
-                            .environmentObject(self.userData)
-                            .environmentObject(self.searchProvider)
-                    }
-                    
-                    Button(action: {
-                        self.showDeleteWarning = true
-                    }) {
-                        Image(systemName: "trash")
-                            .foregroundColor(.red)
-                    }
-                    .padding()
-                    .alert(isPresented: self.$showDeleteWarning) {
-                        Alert(title: Text("Are you sure you want to delete this album from your collection?"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Delete")) {
-                                self.userData.deleteAlbumFromSlot(slotIndex: self.slotIndex)
-                            })
+                    if self.userData.activeCollection.editable {
+                        Button(action: {
+                            self.showSearch = true
+                        }) {
+                            Image(systemName: "arrow.swap")
+                        }
+                        .padding(.vertical)
+                        .sheet(isPresented: self.$showSearch) {
+                            Search(slotIndex: self.slotIndex)
+                                .environmentObject(self.userData)
+                                .environmentObject(self.searchProvider)
+                        }
+                        
+                        Button(action: {
+                            self.showEjectWarning = true
+                        }) {
+                            Image(systemName: "eject")
+                                .foregroundColor(.red)
+                        }
+                        .padding()
+                        .alert(isPresented: self.$showEjectWarning) {
+                            Alert(title: Text("Are you sure you want to eject this album from your collection?"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Eject")) {
+                                    self.userData.ejectSourceFromSlot(slotIndex: self.slotIndex)
+                                })
+                        }
                     }
                 }
             }

--- a/Jewel/Views/SlotDetail.swift
+++ b/Jewel/Views/SlotDetail.swift
@@ -20,7 +20,7 @@ struct SlotDetail: View {
     @State private var showDeleteWarning = false
     
     private func slotDetail() -> some View {
-        if userData.collection.slots[slotIndex].source?.album != nil {
+        if userData.activeCollection.slots[slotIndex].source?.album != nil {
             return AnyView(
                 ScrollView {
                     if horizontalSizeClass == .compact {
@@ -42,7 +42,7 @@ struct SlotDetail: View {
         
         slotDetail()
         .navigationBarItems(trailing:
-            IfLet(userData.collection.slots[slotIndex].source?.album) { album in
+            IfLet(userData.activeCollection.slots[slotIndex].source?.album) { album in
                 HStack {
                     Button(action: {
                         self.showSearch = true

--- a/Jewel/Views/SlotDetail.swift
+++ b/Jewel/Views/SlotDetail.swift
@@ -50,6 +50,7 @@ struct SlotDetail: View {
                         }) {
                             Image(systemName: "arrow.swap")
                         }
+                        .padding(.leading)
                         .padding(.vertical)
                         .sheet(isPresented: self.$showSearch) {
                             Search(slotIndex: self.slotIndex)
@@ -61,9 +62,9 @@ struct SlotDetail: View {
                             self.showEjectWarning = true
                         }) {
                             Image(systemName: "eject")
-                                .foregroundColor(.red)
                         }
-                        .padding()
+                        .padding(.leading)
+                        .padding(.vertical)
                         .alert(isPresented: self.$showEjectWarning) {
                             Alert(title: Text("Are you sure you want to eject this album from your collection?"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Eject")) {
                                     self.userData.ejectSourceFromSlot(slotIndex: self.slotIndex)

--- a/Jewel/Views/SlotDetail.swift
+++ b/Jewel/Views/SlotDetail.swift
@@ -33,7 +33,7 @@ struct SlotDetail: View {
         } else {
             return AnyView(
                 EmptySlot(slotIndex: slotIndex)
-                .padding()
+                    .padding()
             )
         }
     }
@@ -41,38 +41,38 @@ struct SlotDetail: View {
     var body: some View {
         
         slotDetail()
-        .navigationBarItems(trailing:
-            IfLet(userData.activeCollection.slots[slotIndex].source?.album) { album in
-                HStack {
-                    if self.userData.activeCollection.editable {
-                        Button(action: {
-                            self.showSearch = true
-                        }) {
-                            Image(systemName: "arrow.swap")
-                        }
-                        .padding(.leading)
-                        .padding(.vertical)
-                        .sheet(isPresented: self.$showSearch) {
-                            Search(slotIndex: self.slotIndex)
-                                .environmentObject(self.userData)
-                                .environmentObject(self.searchProvider)
-                        }
-                        
-                        Button(action: {
-                            self.showEjectWarning = true
-                        }) {
-                            Image(systemName: "eject")
-                        }
-                        .padding(.leading)
-                        .padding(.vertical)
-                        .alert(isPresented: self.$showEjectWarning) {
-                            Alert(title: Text("Are you sure you want to eject this album from your collection?"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Eject")) {
+            .navigationBarItems(trailing:
+                IfLet(userData.activeCollection.slots[slotIndex].source?.album) { album in
+                    HStack {
+                        if self.userData.activeCollection.editable {
+                            Button(action: {
+                                self.showSearch = true
+                            }) {
+                                Image(systemName: "arrow.swap")
+                            }
+                            .padding(.leading)
+                            .padding(.vertical)
+                            .sheet(isPresented: self.$showSearch) {
+                                Search(slotIndex: self.slotIndex)
+                                    .environmentObject(self.userData)
+                                    .environmentObject(self.searchProvider)
+                            }
+                            
+                            Button(action: {
+                                self.showEjectWarning = true
+                            }) {
+                                Image(systemName: "eject")
+                            }
+                            .padding(.leading)
+                            .padding(.vertical)
+                            .alert(isPresented: self.$showEjectWarning) {
+                                Alert(title: Text("Are you sure you want to eject this album from your collection?"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Eject")) {
                                     self.userData.ejectSourceFromSlot(slotIndex: self.slotIndex)
-                                })
+                                    })
+                            }
                         }
                     }
                 }
-            }
         )
     }
 }


### PR DESCRIPTION
This is a big feature!

You can now share your collection using the standard iOS ShareSheet.  This will create a URL that can be sent like any other URL.

That URL resolves to a page on jewel.breakbeat.io which has been enabled for Universal Links, therefore iOS 13 will redirect the request back into Jewel where it is picked up.

The link is then turned into a collection and loaded into a separate collection in Jewel - there is now the collection of 'mine' and 'theirs'.  The user/my collection is editable as normal, but the shared collection can only be viewed, or currently, reshaped.

There are then some model/class/struct changes to support these features.