### PR TITLE
Migration from Collection to Stack

### DIFF
--- a/Jewel.xcodeproj/project.pbxproj
+++ b/Jewel.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		D20CE85B24AF7AD100039202 /* LibraryActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20CE85A24AF7AD100039202 /* LibraryActions.swift */; };
 		D20CE85D24AF7AEA00039202 /* SearchActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20CE85C24AF7AEA00039202 /* SearchActions.swift */; };
 		D21C40742A9E9C0500BA01AF /* StatePersitenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C40732A9E9C0500BA01AF /* StatePersitenceManager.swift */; };
-		D21C40762A9EA6E500BA01AF /* AppStateV2p0.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C40752A9EA6E500BA01AF /* AppStateV2p0.swift */; };
+		D21C40762A9EA6E500BA01AF /* AppState_v2_0.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C40752A9EA6E500BA01AF /* AppState_v2_0.swift */; };
 		D22155822481114B00A1F04A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D22155812481114B00A1F04A /* Assets.xcassets */; };
 		D22155852481114B00A1F04A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D22155842481114B00A1F04A /* Preview Assets.xcassets */; };
 		D22155882481114B00A1F04A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D22155862481114B00A1F04A /* LaunchScreen.storyboard */; };
@@ -34,7 +34,7 @@
 		D28AD1B5248BACB2009B584A /* PlaybackLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28AD1B4248BACB2009B584A /* PlaybackLink.swift */; };
 		D28AD1B7248BB148009B584A /* PlaybackLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28AD1B6248BB148009B584A /* PlaybackLinks.swift */; };
 		D28AD1B9248BB5D4009B584A /* AlbumDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28AD1B8248BB5D4009B584A /* AlbumDetail.swift */; };
-		D2913F3A2B431B5400000AD1 /* AppStateV2p1.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2913F392B431B5400000AD1 /* AppStateV2p1.swift */; };
+		D2913F3A2B431B5400000AD1 /* AppState_v2_1.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2913F392B431B5400000AD1 /* AppState_v2_1.swift */; };
 		D2945E1C249C0FC100AE6CA5 /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2945E1B249C0FC100AE6CA5 /* Navigation.swift */; };
 		D2945E1E249C249C00AE6CA5 /* SettingsHome.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2945E1D249C249C00AE6CA5 /* SettingsHome.swift */; };
 		D29CB1C724A632520051BA96 /* RichAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CB1C624A632520051BA96 /* RichAlert.swift */; };
@@ -68,7 +68,7 @@
 		D20CE85A24AF7AD100039202 /* LibraryActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryActions.swift; sourceTree = "<group>"; };
 		D20CE85C24AF7AEA00039202 /* SearchActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchActions.swift; sourceTree = "<group>"; };
 		D21C40732A9E9C0500BA01AF /* StatePersitenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatePersitenceManager.swift; sourceTree = "<group>"; };
-		D21C40752A9EA6E500BA01AF /* AppStateV2p0.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateV2p0.swift; sourceTree = "<group>"; };
+		D21C40752A9EA6E500BA01AF /* AppState_v2_0.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState_v2_0.swift; sourceTree = "<group>"; };
 		D22155782481114A00A1F04A /* Stacks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Stacks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D22155812481114B00A1F04A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D22155842481114B00A1F04A /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -93,7 +93,7 @@
 		D28AD1B4248BACB2009B584A /* PlaybackLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackLink.swift; sourceTree = "<group>"; };
 		D28AD1B6248BB148009B584A /* PlaybackLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackLinks.swift; sourceTree = "<group>"; };
 		D28AD1B8248BB5D4009B584A /* AlbumDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetail.swift; sourceTree = "<group>"; };
-		D2913F392B431B5400000AD1 /* AppStateV2p1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateV2p1.swift; sourceTree = "<group>"; };
+		D2913F392B431B5400000AD1 /* AppState_v2_1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState_v2_1.swift; sourceTree = "<group>"; };
 		D2945E1B249C0FC100AE6CA5 /* Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
 		D2945E1D249C249C00AE6CA5 /* SettingsHome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHome.swift; sourceTree = "<group>"; };
 		D29CB1C624A632520051BA96 /* RichAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichAlert.swift; sourceTree = "<group>"; };
@@ -223,8 +223,8 @@
 		D2913F382B431B3000000AD1 /* Previous */ = {
 			isa = PBXGroup;
 			children = (
-				D21C40752A9EA6E500BA01AF /* AppStateV2p0.swift */,
-				D2913F392B431B5400000AD1 /* AppStateV2p1.swift */,
+				D21C40752A9EA6E500BA01AF /* AppState_v2_0.swift */,
+				D2913F392B431B5400000AD1 /* AppState_v2_1.swift */,
 			);
 			path = Previous;
 			sourceTree = "<group>";
@@ -398,7 +398,7 @@
 				D27FB812248693AF0014C05D /* Slot.swift in Sources */,
 				D27FB80E24868AF60014C05D /* Odesli.swift in Sources */,
 				D21C40742A9E9C0500BA01AF /* StatePersitenceManager.swift in Sources */,
-				D2913F3A2B431B5400000AD1 /* AppStateV2p1.swift in Sources */,
+				D2913F3A2B431B5400000AD1 /* AppState_v2_1.swift in Sources */,
 				D28AD1B9248BB5D4009B584A /* AlbumDetail.swift in Sources */,
 				D2945E1E249C249C00AE6CA5 /* SettingsHome.swift in Sources */,
 				D2AC12122485A67000C52D9E /* Search.swift in Sources */,
@@ -425,7 +425,7 @@
 				D2B4FD91248456B20028D7A4 /* StackOptions.swift in Sources */,
 				D2F8D164248A7E2B008C29C3 /* TrackList.swift in Sources */,
 				D2D7858F248A910A00E0CC63 /* AlbumCover.swift in Sources */,
-				D21C40762A9EA6E500BA01AF /* AppStateV2p0.swift in Sources */,
+				D21C40762A9EA6E500BA01AF /* AppState_v2_0.swift in Sources */,
 				D2C3A0A924A01AEF00AA7266 /* NavBar.swift in Sources */,
 				D23C398E248FD2DF00AD237E /* Welcome.swift in Sources */,
 				D2AC120B24859E2300C52D9E /* AddAlbumCardButton.swift in Sources */,

--- a/Jewel.xcodeproj/project.pbxproj
+++ b/Jewel.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		D20CE85B24AF7AD100039202 /* LibraryActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20CE85A24AF7AD100039202 /* LibraryActions.swift */; };
 		D20CE85D24AF7AEA00039202 /* SearchActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20CE85C24AF7AEA00039202 /* SearchActions.swift */; };
 		D21C40742A9E9C0500BA01AF /* StatePersitenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C40732A9E9C0500BA01AF /* StatePersitenceManager.swift */; };
-		D21C40762A9EA6E500BA01AF /* OldAppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C40752A9EA6E500BA01AF /* OldAppState.swift */; };
+		D21C40762A9EA6E500BA01AF /* AppStateV2p0.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C40752A9EA6E500BA01AF /* AppStateV2p0.swift */; };
 		D22155822481114B00A1F04A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D22155812481114B00A1F04A /* Assets.xcassets */; };
 		D22155852481114B00A1F04A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D22155842481114B00A1F04A /* Preview Assets.xcassets */; };
 		D22155882481114B00A1F04A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D22155862481114B00A1F04A /* LaunchScreen.storyboard */; };
@@ -34,6 +34,7 @@
 		D28AD1B5248BACB2009B584A /* PlaybackLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28AD1B4248BACB2009B584A /* PlaybackLink.swift */; };
 		D28AD1B7248BB148009B584A /* PlaybackLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28AD1B6248BB148009B584A /* PlaybackLinks.swift */; };
 		D28AD1B9248BB5D4009B584A /* AlbumDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28AD1B8248BB5D4009B584A /* AlbumDetail.swift */; };
+		D2913F3A2B431B5400000AD1 /* AppStateV2p1.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2913F392B431B5400000AD1 /* AppStateV2p1.swift */; };
 		D2945E1C249C0FC100AE6CA5 /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2945E1B249C0FC100AE6CA5 /* Navigation.swift */; };
 		D2945E1E249C249C00AE6CA5 /* SettingsHome.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2945E1D249C249C00AE6CA5 /* SettingsHome.swift */; };
 		D29CB1C724A632520051BA96 /* RichAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CB1C624A632520051BA96 /* RichAlert.swift */; };
@@ -67,7 +68,7 @@
 		D20CE85A24AF7AD100039202 /* LibraryActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryActions.swift; sourceTree = "<group>"; };
 		D20CE85C24AF7AEA00039202 /* SearchActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchActions.swift; sourceTree = "<group>"; };
 		D21C40732A9E9C0500BA01AF /* StatePersitenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatePersitenceManager.swift; sourceTree = "<group>"; };
-		D21C40752A9EA6E500BA01AF /* OldAppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldAppState.swift; sourceTree = "<group>"; };
+		D21C40752A9EA6E500BA01AF /* AppStateV2p0.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateV2p0.swift; sourceTree = "<group>"; };
 		D22155782481114A00A1F04A /* Stacks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Stacks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D22155812481114B00A1F04A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D22155842481114B00A1F04A /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -92,6 +93,7 @@
 		D28AD1B4248BACB2009B584A /* PlaybackLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackLink.swift; sourceTree = "<group>"; };
 		D28AD1B6248BB148009B584A /* PlaybackLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackLinks.swift; sourceTree = "<group>"; };
 		D28AD1B8248BB5D4009B584A /* AlbumDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetail.swift; sourceTree = "<group>"; };
+		D2913F392B431B5400000AD1 /* AppStateV2p1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateV2p1.swift; sourceTree = "<group>"; };
 		D2945E1B249C0FC100AE6CA5 /* Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
 		D2945E1D249C249C00AE6CA5 /* SettingsHome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHome.swift; sourceTree = "<group>"; };
 		D29CB1C624A632520051BA96 /* RichAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichAlert.swift; sourceTree = "<group>"; };
@@ -205,7 +207,7 @@
 				D2AC12112485A67000C52D9E /* Search.swift */,
 				D2AC120F2485A65D00C52D9E /* Stack.swift */,
 				D27FB811248693AF0014C05D /* Slot.swift */,
-				D21C40752A9EA6E500BA01AF /* OldAppState.swift */,
+				D2913F382B431B3000000AD1 /* Previous */,
 			);
 			path = State;
 			sourceTree = "<group>";
@@ -216,6 +218,15 @@
 				D27FB81F2486B46D0014C05D /* fa-brands.otf */,
 			);
 			path = Fonts;
+			sourceTree = "<group>";
+		};
+		D2913F382B431B3000000AD1 /* Previous */ = {
+			isa = PBXGroup;
+			children = (
+				D21C40752A9EA6E500BA01AF /* AppStateV2p0.swift */,
+				D2913F392B431B5400000AD1 /* AppStateV2p1.swift */,
+			);
+			path = Previous;
 			sourceTree = "<group>";
 		};
 		D2AB846C2481168C008B57F9 /* Views */ = {
@@ -387,6 +398,7 @@
 				D27FB812248693AF0014C05D /* Slot.swift in Sources */,
 				D27FB80E24868AF60014C05D /* Odesli.swift in Sources */,
 				D21C40742A9E9C0500BA01AF /* StatePersitenceManager.swift in Sources */,
+				D2913F3A2B431B5400000AD1 /* AppStateV2p1.swift in Sources */,
 				D28AD1B9248BB5D4009B584A /* AlbumDetail.swift in Sources */,
 				D2945E1E249C249C00AE6CA5 /* SettingsHome.swift in Sources */,
 				D2AC12122485A67000C52D9E /* Search.swift in Sources */,
@@ -413,7 +425,7 @@
 				D2B4FD91248456B20028D7A4 /* StackOptions.swift in Sources */,
 				D2F8D164248A7E2B008C29C3 /* TrackList.swift in Sources */,
 				D2D7858F248A910A00E0CC63 /* AlbumCover.swift in Sources */,
-				D21C40762A9EA6E500BA01AF /* OldAppState.swift in Sources */,
+				D21C40762A9EA6E500BA01AF /* AppStateV2p0.swift in Sources */,
 				D2C3A0A924A01AEF00AA7266 /* NavBar.swift in Sources */,
 				D23C398E248FD2DF00AD237E /* Welcome.swift in Sources */,
 				D2AC120B24859E2300C52D9E /* AddAlbumCardButton.swift in Sources */,

--- a/Jewel.xcodeproj/project.pbxproj
+++ b/Jewel.xcodeproj/project.pbxproj
@@ -40,22 +40,22 @@
 		D2AB8467248113EB008B57F9 /* AppAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AB8466248113EB008B57F9 /* AppAction.swift */; };
 		D2AB846B2481159D008B57F9 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AB846A2481159D008B57F9 /* AppEnvironment.swift */; };
 		D2AC120B24859E2300C52D9E /* AddAlbumCardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AC120A24859E2300C52D9E /* AddAlbumCardButton.swift */; };
-		D2AC12102485A65D00C52D9E /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AC120F2485A65D00C52D9E /* Collection.swift */; };
+		D2AC12102485A65D00C52D9E /* Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AC120F2485A65D00C52D9E /* Stack.swift */; };
 		D2AC12122485A67000C52D9E /* Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AC12112485A67000C52D9E /* Search.swift */; };
-		D2B4FD91248456B20028D7A4 /* CollectionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B4FD90248456B20028D7A4 /* CollectionOptions.swift */; };
+		D2B4FD91248456B20028D7A4 /* StackOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B4FD90248456B20028D7A4 /* StackOptions.swift */; };
 		D2B4FD95248458300028D7A4 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B4FD94248458300028D7A4 /* Extensions.swift */; };
 		D2C269562A9FC56D00C87686 /* DebugActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C269552A9FC56D00C87686 /* DebugActions.swift */; };
 		D2C3A0A5249FFEFF00AA7266 /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C3A0A4249FFEFF00AA7266 /* Home.swift */; };
 		D2C3A0A724A01ADE00AA7266 /* OnRotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C3A0A624A01ADE00AA7266 /* OnRotation.swift */; };
 		D2C3A0A924A01AEF00AA7266 /* NavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C3A0A824A01AEF00AA7266 /* NavBar.swift */; };
-		D2C3A0AB24A0202100AA7266 /* CollectionLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C3A0AA24A0202100AA7266 /* CollectionLibrary.swift */; };
-		D2C810EE24A4FF47003D9B59 /* CollectionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C810ED24A4FF47003D9B59 /* CollectionSheet.swift */; };
+		D2C3A0AB24A0202100AA7266 /* StackLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C3A0AA24A0202100AA7266 /* StackLibrary.swift */; };
+		D2C810EE24A4FF47003D9B59 /* StackSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C810ED24A4FF47003D9B59 /* StackSheet.swift */; };
 		D2D7858F248A910A00E0CC63 /* AlbumCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D7858E248A910A00E0CC63 /* AlbumCover.swift */; };
 		D2D78591248AED2900E0CC63 /* AlternativePlaybackLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D78590248AED2900E0CC63 /* AlternativePlaybackLinks.swift */; };
 		D2D78593248AF2E900E0CC63 /* AlbumCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D78592248AF2E900E0CC63 /* AlbumCard.swift */; };
 		D2DB0FCE24A7782B006A5835 /* stateScreenshotData.json in Resources */ = {isa = PBXBuildFile; fileRef = D2DB0FCA24A7782B006A5835 /* stateScreenshotData.json */; };
-		D2F0E220249A370A00EA3FA2 /* CollectionDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F0E21F249A370A00EA3FA2 /* CollectionDetail.swift */; };
-		D2F8D14C248A6451008C29C3 /* CollectionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F8D14B248A6451008C29C3 /* CollectionCard.swift */; };
+		D2F0E220249A370A00EA3FA2 /* StackDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F0E21F249A370A00EA3FA2 /* StackDetail.swift */; };
+		D2F8D14C248A6451008C29C3 /* StackCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F8D14B248A6451008C29C3 /* StackCard.swift */; };
 		D2F8D14E248A666C008C29C3 /* CardArtworkComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F8D14D248A666C008C29C3 /* CardArtworkComposite.swift */; };
 		D2F8D164248A7E2B008C29C3 /* TrackList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F8D163248A7E2B008C29C3 /* TrackList.swift */; };
 		D2F8D166248A7E42008C29C3 /* DiscTrackList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F8D165248A7E42008C29C3 /* DiscTrackList.swift */; };
@@ -98,22 +98,22 @@
 		D2AB8466248113EB008B57F9 /* AppAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAction.swift; sourceTree = "<group>"; };
 		D2AB846A2481159D008B57F9 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		D2AC120A24859E2300C52D9E /* AddAlbumCardButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAlbumCardButton.swift; sourceTree = "<group>"; };
-		D2AC120F2485A65D00C52D9E /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
+		D2AC120F2485A65D00C52D9E /* Stack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stack.swift; sourceTree = "<group>"; };
 		D2AC12112485A67000C52D9E /* Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
-		D2B4FD90248456B20028D7A4 /* CollectionOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionOptions.swift; sourceTree = "<group>"; };
+		D2B4FD90248456B20028D7A4 /* StackOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackOptions.swift; sourceTree = "<group>"; };
 		D2B4FD94248458300028D7A4 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		D2C269552A9FC56D00C87686 /* DebugActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugActions.swift; sourceTree = "<group>"; };
 		D2C3A0A4249FFEFF00AA7266 /* Home.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
 		D2C3A0A624A01ADE00AA7266 /* OnRotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnRotation.swift; sourceTree = "<group>"; };
 		D2C3A0A824A01AEF00AA7266 /* NavBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavBar.swift; sourceTree = "<group>"; };
-		D2C3A0AA24A0202100AA7266 /* CollectionLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionLibrary.swift; sourceTree = "<group>"; };
-		D2C810ED24A4FF47003D9B59 /* CollectionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSheet.swift; sourceTree = "<group>"; };
+		D2C3A0AA24A0202100AA7266 /* StackLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackLibrary.swift; sourceTree = "<group>"; };
+		D2C810ED24A4FF47003D9B59 /* StackSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackSheet.swift; sourceTree = "<group>"; };
 		D2D7858E248A910A00E0CC63 /* AlbumCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumCover.swift; sourceTree = "<group>"; };
 		D2D78590248AED2900E0CC63 /* AlternativePlaybackLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlternativePlaybackLinks.swift; sourceTree = "<group>"; };
 		D2D78592248AF2E900E0CC63 /* AlbumCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumCard.swift; sourceTree = "<group>"; };
 		D2DB0FCA24A7782B006A5835 /* stateScreenshotData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = stateScreenshotData.json; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.json; };
-		D2F0E21F249A370A00EA3FA2 /* CollectionDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionDetail.swift; sourceTree = "<group>"; };
-		D2F8D14B248A6451008C29C3 /* CollectionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionCard.swift; sourceTree = "<group>"; };
+		D2F0E21F249A370A00EA3FA2 /* StackDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackDetail.swift; sourceTree = "<group>"; };
+		D2F8D14B248A6451008C29C3 /* StackCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackCard.swift; sourceTree = "<group>"; };
 		D2F8D14D248A666C008C29C3 /* CardArtworkComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardArtworkComposite.swift; sourceTree = "<group>"; };
 		D2F8D163248A7E2B008C29C3 /* TrackList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackList.swift; sourceTree = "<group>"; };
 		D2F8D165248A7E42008C29C3 /* DiscTrackList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscTrackList.swift; sourceTree = "<group>"; };
@@ -203,7 +203,7 @@
 				D27FB80F24868B320014C05D /* Settings.swift */,
 				D24C80D024899D0C00EFACD8 /* Library.swift */,
 				D2AC12112485A67000C52D9E /* Search.swift */,
-				D2AC120F2485A65D00C52D9E /* Collection.swift */,
+				D2AC120F2485A65D00C52D9E /* Stack.swift */,
 				D27FB811248693AF0014C05D /* Slot.swift */,
 				D21C40752A9EA6E500BA01AF /* OldAppState.swift */,
 			);
@@ -226,8 +226,8 @@
 				D23C398D248FD2DF00AD237E /* Welcome.swift */,
 				D2C3A0A824A01AEF00AA7266 /* NavBar.swift */,
 				D2C3A0A624A01ADE00AA7266 /* OnRotation.swift */,
-				D2C3A0AA24A0202100AA7266 /* CollectionLibrary.swift */,
-				D2C810ED24A4FF47003D9B59 /* CollectionSheet.swift */,
+				D2C3A0AA24A0202100AA7266 /* StackLibrary.swift */,
+				D2C810ED24A4FF47003D9B59 /* StackSheet.swift */,
 				D2B4FD8F248456940028D7A4 /* Options */,
 				D24925932481410F0011F409 /* Search */,
 				D2F8D162248A7E1A008C29C3 /* Components */,
@@ -269,7 +269,7 @@
 			isa = PBXGroup;
 			children = (
 				D2945E1D249C249C00AE6CA5 /* SettingsHome.swift */,
-				D2B4FD90248456B20028D7A4 /* CollectionOptions.swift */,
+				D2B4FD90248456B20028D7A4 /* StackOptions.swift */,
 			);
 			path = Options;
 			sourceTree = "<group>";
@@ -289,9 +289,9 @@
 				D29CB1C624A632520051BA96 /* RichAlert.swift */,
 				D2AC120A24859E2300C52D9E /* AddAlbumCardButton.swift */,
 				D2D78592248AF2E900E0CC63 /* AlbumCard.swift */,
-				D2F8D14B248A6451008C29C3 /* CollectionCard.swift */,
+				D2F8D14B248A6451008C29C3 /* StackCard.swift */,
 				D2F8D14D248A666C008C29C3 /* CardArtworkComposite.swift */,
-				D2F0E21F249A370A00EA3FA2 /* CollectionDetail.swift */,
+				D2F0E21F249A370A00EA3FA2 /* StackDetail.swift */,
 				D28AD1B8248BB5D4009B584A /* AlbumDetail.swift */,
 				D2D7858E248A910A00E0CC63 /* AlbumCover.swift */,
 				D28AD1B6248BB148009B584A /* PlaybackLinks.swift */,
@@ -395,22 +395,22 @@
 				D29CB1C724A632520051BA96 /* RichAlert.swift in Sources */,
 				D23197C22492DACD00C09977 /* Constants.swift in Sources */,
 				D20CE85B24AF7AD100039202 /* LibraryActions.swift in Sources */,
-				D2C810EE24A4FF47003D9B59 /* CollectionSheet.swift in Sources */,
-				D2C3A0AB24A0202100AA7266 /* CollectionLibrary.swift in Sources */,
+				D2C810EE24A4FF47003D9B59 /* StackSheet.swift in Sources */,
+				D2C3A0AB24A0202100AA7266 /* StackLibrary.swift in Sources */,
 				D2D78593248AF2E900E0CC63 /* AlbumCard.swift in Sources */,
 				D2492599248143720011F409 /* SearchResults.swift in Sources */,
 				D249258F24811A650011F409 /* SearchHome.swift in Sources */,
 				D20CE85724AF7A4600039202 /* NavigationActions.swift in Sources */,
-				D2F8D14C248A6451008C29C3 /* CollectionCard.swift in Sources */,
+				D2F8D14C248A6451008C29C3 /* StackCard.swift in Sources */,
 				D28AD1B7248BB148009B584A /* PlaybackLinks.swift in Sources */,
-				D2F0E220249A370A00EA3FA2 /* CollectionDetail.swift in Sources */,
+				D2F0E220249A370A00EA3FA2 /* StackDetail.swift in Sources */,
 				D24C80D124899D0C00EFACD8 /* Library.swift in Sources */,
 				D20CE85D24AF7AEA00039202 /* SearchActions.swift in Sources */,
 				D2AB846B2481159D008B57F9 /* AppEnvironment.swift in Sources */,
 				D2C3A0A724A01ADE00AA7266 /* OnRotation.swift in Sources */,
-				D2AC12102485A65D00C52D9E /* Collection.swift in Sources */,
+				D2AC12102485A65D00C52D9E /* Stack.swift in Sources */,
 				D2B4FD95248458300028D7A4 /* Extensions.swift in Sources */,
-				D2B4FD91248456B20028D7A4 /* CollectionOptions.swift in Sources */,
+				D2B4FD91248456B20028D7A4 /* StackOptions.swift in Sources */,
 				D2F8D164248A7E2B008C29C3 /* TrackList.swift in Sources */,
 				D2D7858F248A910A00E0CC63 /* AlbumCover.swift in Sources */,
 				D21C40762A9EA6E500BA01AF /* OldAppState.swift in Sources */,

--- a/Jewel/Actions/AppAction.swift
+++ b/Jewel/Actions/AppAction.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import os.log
 
 protocol AppAction {
   var description: String { get }
@@ -38,7 +37,7 @@ func updateState(appState: AppState, action: AppAction) -> AppState {
     
   }
   
-  os_log("💎 State Update > %s", action.description)
+    JewelLogger.stateUpdate.info("💎 State Update > \(action.description)")
   
   return newAppState
 }

--- a/Jewel/Actions/DebugActions.swift
+++ b/Jewel/Actions/DebugActions.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import os.log
 import MusicKit
 
 func debugUpdate(state: AppState, action: DebugAction) -> AppState {
@@ -25,7 +24,7 @@ func debugUpdate(state: AppState, action: DebugAction) -> AppState {
         let screenshotState = try decoder.decode(AppState.self, from: data)
         newState = screenshotState
       } catch {
-        os_log("💎 Screenshot Generator > Error with state: %s", error.localizedDescription)
+        JewelLogger.debugAction.debug("💎 Screenshot Generator > Error with state: \(error.localizedDescription)")
       }
     }
     
@@ -39,7 +38,7 @@ func debugUpdate(state: AppState, action: DebugAction) -> AppState {
         newState.search.results = searchResults
         
       } catch {
-        os_log("💎 Screenshot Generator > Error wtih search results: %s", error.localizedDescription)
+        JewelLogger.debugAction.debug("💎 Screenshot Generator > Error wtih search results: \(error.localizedDescription)")
       }
     }
 

--- a/Jewel/Actions/LibraryActions.swift
+++ b/Jewel/Actions/LibraryActions.swift
@@ -11,20 +11,20 @@ import MusicKit
 
 func updateLibrary(library: Library, action: LibraryAction) -> Library {
   
-  func extractCollection(collectionId: UUID) -> Collection? {
-    if newLibrary.onRotation.id == collectionId {
+  func extractStack(stackId: UUID) -> Stack? {
+    if newLibrary.onRotation.id == stackId {
       return newLibrary.onRotation
-    } else if let collectionIndex = newLibrary.collections.firstIndex(where: { $0.id == collectionId }) {
-      return newLibrary.collections[collectionIndex]
+    } else if let stackIndex = newLibrary.stacks.firstIndex(where: { $0.id == stackId }) {
+      return newLibrary.stacks[stackIndex]
     }
     return nil
   }
   
-  func commitCollection(collection: Collection) {
-    if collection.id == newLibrary.onRotation.id {
-      newLibrary.onRotation = collection
-    } else if let collectionIndex = newLibrary.collections.firstIndex(where: { $0.id == collection.id }) {
-      newLibrary.collections[collectionIndex] = collection
+  func commitStack(stack: Stack) {
+    if stack.id == newLibrary.onRotation.id {
+      newLibrary.onRotation = stack
+    } else if let stackIndex = newLibrary.stacks.firstIndex(where: { $0.id == stack.id }) {
+      newLibrary.stacks[stackIndex] = stack
     }
   }
   
@@ -32,56 +32,56 @@ func updateLibrary(library: Library, action: LibraryAction) -> Library {
   
   switch action {
     
-  case let .setCollectionName(name, collectionId):
-    if var collection = extractCollection(collectionId: collectionId) {
-      collection.name = name
-      commitCollection(collection: collection)
+  case let .setStackName(name, stackId):
+    if var stack = extractStack(stackId: stackId) {
+      stack.name = name
+      commitStack(stack: stack)
     }
     
-  case let .addAlbumToSlot(album, slotIndex, collectionId):
-    if var collection = extractCollection(collectionId: collectionId) {
-      collection.slots[slotIndex].album = album
-      commitCollection(collection: collection)
+  case let .addAlbumToSlot(album, slotIndex, stackId):
+    if var stack = extractStack(stackId: stackId) {
+      stack.slots[slotIndex].album = album
+      commitStack(stack: stack)
     }
     
-  case let .removeAlbumFromSlot(slotIndex, collectionId):
-    if var collection = extractCollection(collectionId: collectionId) {
-      collection.slots[slotIndex] = Slot()
-      commitCollection(collection: collection)
+  case let .removeAlbumFromSlot(slotIndex, stackId):
+    if var stack = extractStack(stackId: stackId) {
+      stack.slots[slotIndex] = Slot()
+      commitStack(stack: stack)
     }
     
-  case let .saveOnRotation(collection):
+  case let .saveOnRotation(stack):
     let formatter = DateFormatter()
     formatter.dateFormat = "dd MMM ''yy"
     let dateString = formatter.string(from: Date())
-    var newCollection = collection
-    newCollection.id = UUID()
-    newCollection.name = "\(Navigation.Tab.onRotation.rawValue) (\(dateString))"
-    newLibrary.collections.insert(newCollection, at: 0)
+    var newStack = stack
+    newStack.id = UUID()
+    newStack.name = "\(Navigation.Tab.onRotation.rawValue) (\(dateString))"
+    newLibrary.stacks.insert(newStack, at: 0)
     
-  case .createCollection:
-    let newCollection = Collection(name: "New Collection")
-    newLibrary.collections.insert(newCollection, at: 0)
+  case .createStack:
+    let newStack = Stack(name: "New Stack")
+    newLibrary.stacks.insert(newStack, at: 0)
     
-  case let .addCollection(collection):
-    newLibrary.collections.insert(collection, at: 0)
+  case let .addStack(stack):
+    newLibrary.stacks.insert(stack, at: 0)
     
-  case let .duplicateCollection(collection):
-    var duplicatedCollection = collection
-    duplicatedCollection.id = UUID()
-    duplicatedCollection.name = "Copy of \(collection.name)"
-    newLibrary.collections.insert(duplicatedCollection, at: 0)
+  case let .duplicateStack(stack):
+    var duplicatedStack = stack
+    duplicatedStack.id = UUID()
+    duplicatedStack.name = "Copy of \(stack.name)"
+    newLibrary.stacks.insert(duplicatedStack, at: 0)
     
-  case let .removeCollection(collectionId):
-    newLibrary.collections.removeAll(where: { $0.id == collectionId })
+  case let .removeStack(stackId):
+    newLibrary.stacks.removeAll(where: { $0.id == stackId })
     
-  case let .setPlaybackLinks(baseUrl, playbackLinks, collectionId):
-    if var collection = extractCollection(collectionId: collectionId) {
-      let indices = collection.slots.enumerated().compactMap({ $1.album?.url == baseUrl ? $0 : nil })
+  case let .setPlaybackLinks(baseUrl, playbackLinks, stackId):
+    if var stack = extractStack(stackId: stackId) {
+      let indices = stack.slots.enumerated().compactMap({ $1.album?.url == baseUrl ? $0 : nil })
       for i in indices {
-        collection.slots[i].playbackLinks = playbackLinks
+        stack.slots[i].playbackLinks = playbackLinks
       }
-      commitCollection(collection: collection)
+      commitStack(stack: stack)
     }
     
   }
@@ -92,45 +92,45 @@ func updateLibrary(library: Library, action: LibraryAction) -> Library {
 
 enum LibraryAction: AppAction {
   
-  case setCollectionName(name: String, collectionId: UUID)
-  case addAlbumToSlot(album: Album, slotIndex: Int, collectionId: UUID)
-  case removeAlbumFromSlot(slotIndex: Int, collectionId: UUID)
-  case setPlaybackLinks(baseUrl: URL, playbackLinks: OdesliResponse, collectionId: UUID)
-  case saveOnRotation(collection: Collection)
-  case createCollection
-  case addCollection(collection: Collection)
-  case duplicateCollection(collection: Collection)
-  case removeCollection(collectionId: UUID)
+  case setStackName(name: String, stackId: UUID)
+  case addAlbumToSlot(album: Album, slotIndex: Int, stackId: UUID)
+  case removeAlbumFromSlot(slotIndex: Int, stackId: UUID)
+  case setPlaybackLinks(baseUrl: URL, playbackLinks: OdesliResponse, stackId: UUID)
+  case saveOnRotation(stack: Stack)
+  case createStack
+  case addStack(stack: Stack)
+  case duplicateStack(stack: Stack)
+  case removeStack(stackId: UUID)
   
   var description: String {
     switch self {
       
-    case .setCollectionName(let name, _):
-      return "\(type(of: self)): Setting user collection name to \(name)"
+    case .setStackName(let name, _):
+      return "\(type(of: self)): Setting user stack name to \(name)"
       
-    case .addAlbumToSlot(let album, let slotIndex, let collectionId):
-      return "\(type(of: self)): Adding AppleMusicAlbum \(album.id) to slot \(slotIndex) in collection \(collectionId)"
+    case .addAlbumToSlot(let album, let slotIndex, let stackId):
+      return "\(type(of: self)): Adding AppleMusicAlbum \(album.id) to slot \(slotIndex) in stack \(stackId)"
       
-    case .removeAlbumFromSlot(let slotIndex, let collectionId):
-      return "\(type(of: self)): Removing album in slot \(slotIndex) from collection \(collectionId)"
+    case .removeAlbumFromSlot(let slotIndex, let stackId):
+      return "\(type(of: self)): Removing album in slot \(slotIndex) from stack \(stackId)"
       
-    case .setPlaybackLinks(let baseUrl, _, let collectionId):
-      return "\(type(of: self)): Setting platform links for any album with \(baseUrl) in \(collectionId)"
+    case .setPlaybackLinks(let baseUrl, _, let stackId):
+      return "\(type(of: self)): Setting platform links for any album with \(baseUrl) in \(stackId)"
       
     case .saveOnRotation:
       return "\(type(of: self)): Saving current On Rotation to Library"
       
-    case .createCollection:
-      return "\(type(of: self)): Creating a user collection in the Library"
+    case .createStack:
+      return "\(type(of: self)): Creating a user stack in the Library"
       
-    case .addCollection:
-      return "\(type(of: self)): Adding a collection to the library"
+    case .addStack:
+      return "\(type(of: self)): Adding a stack to the library"
       
-    case .duplicateCollection(let collection):
-      return "\(type(of: self)): Making a copy of collection \(collection.id)"
+    case .duplicateStack(let stack):
+      return "\(type(of: self)): Making a copy of stack \(stack.id)"
       
-    case .removeCollection(let collectionId):
-      return "\(type(of: self)): Removing collection \(collectionId) from the Library"
+    case .removeStack(let stackId):
+      return "\(type(of: self)): Removing stack \(stackId) from the Library"
       
     }
   }

--- a/Jewel/Actions/NavigationActions.swift
+++ b/Jewel/Actions/NavigationActions.swift
@@ -18,8 +18,8 @@ func updateNavigation(navigation: Navigation, action: NavigationAction) -> Navig
   case let .switchTab(toTab):
     newNavigation.selectedTab = toTab
   
-  case let .setActiveCollectionId(collectionId):
-    newNavigation.activeCollectionId = collectionId
+  case let .setActiveStackId(stackId):
+    newNavigation.activeStackId = stackId
     
   case let .setActiveSlotIndex(slotIndex):
     newNavigation.activeSlotIndex = slotIndex
@@ -30,11 +30,11 @@ func updateNavigation(navigation: Navigation, action: NavigationAction) -> Navig
   case let .showSearch(showSearchState):
     newNavigation.showSearch = showSearchState
 
-  case let .showCollection(showCollectionState):
-    newNavigation.showCollection = showCollectionState
+  case let .showStack(showStackState):
+    newNavigation.showStack = showStackState
   
-  case let .showCollectionOptions(showCollectionOptionsState):
-    newNavigation.showCollectionOptions = showCollectionOptionsState
+  case let .showStackOptions(showStackOptionsState):
+    newNavigation.showStackOptions = showStackOptionsState
   
   case let .showLibraryOptions(showLibraryOptionsState):
     newNavigation.showLibraryOptions = showLibraryOptionsState
@@ -51,14 +51,14 @@ func updateNavigation(navigation: Navigation, action: NavigationAction) -> Navig
   case let .gettingSearchResults(gettingSearchResultsState):
     newNavigation.gettingSearchResults = gettingSearchResultsState
     
-  case let .setCollectionViewHeight(viewHeight):
-    newNavigation.collectionViewHeight = viewHeight
+  case let .setStackViewHeight(viewHeight):
+    newNavigation.stackViewHeight = viewHeight
   
   case let .setLibraryViewHeight(viewHeight):
   newNavigation.libraryViewHeight = viewHeight
   
   case .reset:
-    newNavigation = Navigation(onRotationId: newNavigation.onRotationId, activeCollectionId: newNavigation.activeCollectionId)
+    newNavigation = Navigation(onRotationId: newNavigation.onRotationId, activeStackId: newNavigation.activeStackId)
     
   case .toggleDebug:
     newNavigation.showDebugMenu.toggle()
@@ -72,18 +72,18 @@ func updateNavigation(navigation: Navigation, action: NavigationAction) -> Navig
 enum NavigationAction: AppAction {
   
   case switchTab(to: Navigation.Tab)
-  case setActiveCollectionId(collectionId: UUID)
+  case setActiveStackId(stackId: UUID)
   case setActiveSlotIndex(slotIndex: Int)
   case showSettings(Bool)
   case showSearch(Bool)
-  case showCollection(Bool)
-  case showCollectionOptions(Bool)
+  case showStack(Bool)
+  case showStackOptions(Bool)
   case showLibraryOptions(Bool)
   case showAlbumDetail(Bool)
   case showPlaybackLinks(Bool)
   case gettingPlaybackLinks(Bool)
   case gettingSearchResults(Bool)
-  case setCollectionViewHeight(viewHeight: CGFloat)
+  case setStackViewHeight(viewHeight: CGFloat)
   case setLibraryViewHeight(viewHeight: CGFloat)
   case reset
   case toggleDebug
@@ -92,18 +92,18 @@ enum NavigationAction: AppAction {
     switch self {
     case .switchTab(let tab):
       return "\(type(of: self)): Switching to \(tab.rawValue) tab"
-    case .setActiveCollectionId(let collectionId):
-      return "\(type(of: self)): Setting active collection to \(collectionId)"
+    case .setActiveStackId(let stackId):
+      return "\(type(of: self)): Setting active stack to \(stackId)"
     case .setActiveSlotIndex(let slotId):
       return "\(type(of: self)): Setting active slot to \(slotId)"
     case .showSettings(let showing):
       return "\(type(of: self)): \(showing ? "Showing" : "Closing") settings"
     case .showSearch(let showing):
       return "\(type(of: self)): \(showing ? "Showing" : "Closing") search"
-    case .showCollection(let showing):
-      return "\(type(of: self)): \(showing ? "Showing" : "Closing") collection"
-    case .showCollectionOptions(let showing):
-      return "\(type(of: self)): \(showing ? "Showing" : "Closing") collection options"
+    case .showStack(let showing):
+      return "\(type(of: self)): \(showing ? "Showing" : "Closing") stack"
+    case .showStackOptions(let showing):
+      return "\(type(of: self)): \(showing ? "Showing" : "Closing") stack options"
     case .showLibraryOptions(let showing):
       return "\(type(of: self)): \(showing ? "Showing" : "Closing") library options"
     case .showAlbumDetail(let showing):
@@ -114,8 +114,8 @@ enum NavigationAction: AppAction {
       return "\(type(of: self)): \(showing ? "Showing" : "Hiding") playback links spinner"
     case .gettingSearchResults(let showing):
       return "\(type(of: self)): \(showing ? "Showing" : "Closing") search spinner"
-    case .setCollectionViewHeight(let height):
-      return "\(type(of: self)): Setting collection view height to \(height)"
+    case .setStackViewHeight(let height):
+      return "\(type(of: self)): Setting stack view height to \(height)"
     case .setLibraryViewHeight(let height):
       return "\(type(of: self)): Setting library view height to \(height)"
     case .reset:

--- a/Jewel/App/AppEnvironment.swift
+++ b/Jewel/App/AppEnvironment.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import os.log
 import UIKit
 
 final class AppEnvironment: ObservableObject {

--- a/Jewel/App/JewelApp.swift
+++ b/Jewel/App/JewelApp.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Breakbeat Ltd. All rights reserved.
 //
 
+import OSLog
 import SwiftUI
 import MusicKit
 
@@ -25,4 +26,11 @@ struct JewelApp: App {
     }
   }
   
+}
+
+struct JewelLogger {
+    static let persistence = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "persistence")
+    static let stateUpdate = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "stateUpdate")
+    static let recordStore = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "recordStore")
+    static let debugAction = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "debugAction")
 }

--- a/Jewel/Screenshot Data/stateScreenshotData.json
+++ b/Jewel/Screenshot Data/stateScreenshotData.json
@@ -4,7 +4,7 @@
     "first_time_run" : false
   },
   "library" : {
-    "collections" : [
+    "stacks" : [
       {
         "id" : "AE652C2A-D8E8-4027-8C13-C5149D8613FD",
         "name" : "Road Trip 2023",

--- a/Jewel/Services/RecordStore.swift
+++ b/Jewel/Services/RecordStore.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import os.log
 import MusicKit
 
 enum RecordStoreError: Error {
@@ -17,51 +16,51 @@ enum RecordStoreError: Error {
 class RecordStore {
   
   static func search(for searchTerm: String) async throws -> MusicItemCollection<Album> {
-    os_log("💎 Record Store > Searching for '\(searchTerm)'")
+    JewelLogger.recordStore.info("💎 Record Store > Searching for '\(searchTerm)'")
     do {
       var searchRequest = MusicCatalogSearchRequest(term: searchTerm, types: [Album.self])
       searchRequest.limit = 20
       return try await searchRequest.response().albums
     } catch {
-      os_log("💎 Record Store > Search error: %s", String(describing: error))
+      JewelLogger.recordStore.debug("💎 Record Store > Search error: \(String(describing: error))")
       throw error
     }
   }
   
   static func getAlbum(withId appleMusicAlbumId: MusicItemID) async throws -> Album {
-    os_log("💎 Record Store > Getting Album with ID \(appleMusicAlbumId.rawValue)")
+    JewelLogger.recordStore.info("💎 Record Store > Getting Album with ID \(appleMusicAlbumId.rawValue)")
     do {
       var albumRequest = MusicCatalogResourceRequest<Album>(matching: \.id, equalTo: appleMusicAlbumId)
       albumRequest.properties = [.tracks]
       let albumResponse = try await albumRequest.response()
       
       guard let album = albumResponse.items.first else {
-        os_log("💎 Record Store > Get album error: Unable to find Album with ID \(appleMusicAlbumId)")
+        JewelLogger.recordStore.info("💎 Record Store > Unable to find Album with ID \(appleMusicAlbumId)")
         throw RecordStoreError.NotFound(appleMusicAlbumId)
       }
       
       return album
       
     } catch {
-      os_log("💎 Record Store > Get album error: %s", String(describing: error))
+      JewelLogger.recordStore.debug("💎 Record Store > Get album error: \(String(describing: error))")
       throw error
     }
   }
   
   static func getPlaybackLinks(for baseUrl: URL) async throws -> OdesliResponse {
-    os_log("💎 Playback Links > Populating links for %s", baseUrl.absoluteString)
+    JewelLogger.recordStore.info("💎 Playback Links > Populating links for \(baseUrl.absoluteString)")
     do {
       let (data, response) = try await URLSession.shared.data(from: URL(string: "https://api.song.link/v1-alpha.1/links?url=\(baseUrl.absoluteString)")!) as! (Data, HTTPURLResponse)
       
       if response.statusCode != 200 {
-        os_log("💎 Playback Links > Unexpected URL response code: %s", response.statusCode)
+        JewelLogger.recordStore.debug("💎 Playback Links > Unexpected URL response code: \(response.statusCode)")
       }
       
       let playbackLinks = try JSONDecoder().decode(OdesliResponse.self, from: data)
       return playbackLinks
       
     } catch {
-      os_log("💎 Playback Links > Error getting playbackLinks: %s", error.localizedDescription)
+      JewelLogger.recordStore.debug("💎 Playback Links > Error getting playbackLinks: \(error.localizedDescription)")
       throw error
     }
   }

--- a/Jewel/Services/StatePersitenceManager.swift
+++ b/Jewel/Services/StatePersitenceManager.swift
@@ -10,14 +10,12 @@ import Foundation
 
 struct StatePersitenceManager {
   
-  private static let stateVersionKey = "jewelState_v3_0"
-  
   static func save(_ state: AppState) {
     do {
       let encoder = JSONEncoder()
       encoder.keyEncodingStrategy = .convertToSnakeCase
       let encodedState = try encoder.encode(state)
-      UserDefaults.standard.set(encodedState, forKey: stateVersionKey)
+      UserDefaults.standard.set(encodedState, forKey: AppState.versionKey)
     } catch {
       JewelLogger.persistence.debug("💎 Persistence > Error saving state: \(error.localizedDescription)")
     }
@@ -34,7 +32,7 @@ struct StatePersitenceManager {
   static func savedState() -> AppState? {
     
     JewelLogger.persistence.info("💎 Persistence > Looking for a current saved state")
-    guard let savedState = UserDefaults.standard.object(forKey: stateVersionKey) as? Data else {
+    guard let savedState = UserDefaults.standard.object(forKey: AppState.versionKey) as? Data else {
       JewelLogger.persistence.info("💎 Persistence > No current saved state found")
       return nil
     }
@@ -79,7 +77,7 @@ struct StatePersitenceManager {
     private static func migrate_v2_1_to_v3_0() {
       
       JewelLogger.persistence.info("💎 Persistence > Looking for a v2.1 saved state")
-      guard let v2_1_StateData = UserDefaults.standard.object(forKey: "jewelState_2_1") as? Data else {
+      guard let v2_1_StateData = UserDefaults.standard.object(forKey: AppState_v2_1.versionKey) as? Data else {
         JewelLogger.persistence.info("💎 Persistence > No v2.1 saved state found")
         return
       }
@@ -130,10 +128,10 @@ struct StatePersitenceManager {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         let encodedState = try encoder.encode(v3_0_State)
-        UserDefaults.standard.set(encodedState, forKey: stateVersionKey)
+        UserDefaults.standard.set(encodedState, forKey: AppState.versionKey)
         
         JewelLogger.persistence.info("💎 Persistence > Migration successful, deleting v2.1 saved state")
-        UserDefaults.standard.removeObject(forKey: "jewelState_2_1")
+        UserDefaults.standard.removeObject(forKey: AppState_v2_1.versionKey)
         
         UserDefaults.standard.synchronize()
         
@@ -141,7 +139,7 @@ struct StatePersitenceManager {
         JewelLogger.persistence.debug("💎 Persistence > Error migrating a v2.1 state: \(error.localizedDescription)")
         // Something's gone wrong and we haven't handled it, but now a new state will be created and take precedence
         // so to avoid future problems we should remove the remnants of the old state.
-        UserDefaults.standard.removeObject(forKey: "jewelState_2_1")
+        UserDefaults.standard.removeObject(forKey: AppState_v2_1.versionKey)
       }
       
     }
@@ -150,7 +148,7 @@ struct StatePersitenceManager {
       
       JewelLogger.persistence.info("💎 Persistence > Looking for a v2.0 saved state")
       
-      guard let v2_0_StateData = UserDefaults.standard.object(forKey: "jewelState") as? Data else {
+      guard let v2_0_StateData = UserDefaults.standard.object(forKey: AppState_v2_0.versionKey) as? Data else {
         JewelLogger.persistence.info("💎 Persistence > No v2.0 saved state found")
         return
       }
@@ -202,10 +200,10 @@ struct StatePersitenceManager {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         let encodedState = try encoder.encode(v2_1_State)
-        UserDefaults.standard.set(encodedState, forKey: "jewelState_2_1")
+        UserDefaults.standard.set(encodedState, forKey: AppState_v2_1.versionKey)
         
         JewelLogger.persistence.info("💎 Persistence > Migration successful, deleting v2.0 saved state")
-        UserDefaults.standard.removeObject(forKey: "jewelState")
+        UserDefaults.standard.removeObject(forKey: AppState_v2_0.versionKey)
         
         UserDefaults.standard.synchronize()
         
@@ -213,7 +211,7 @@ struct StatePersitenceManager {
         JewelLogger.persistence.debug("💎 Persistence > Error migrating a v2.0 state: \(error.localizedDescription)")
         // Something's gone wrong and we haven't handled it, but now a new state will be created and take precedence
         // so to avoid future problems we should remove the remnants of the old state.
-        UserDefaults.standard.removeObject(forKey: "jewelState")
+        UserDefaults.standard.removeObject(forKey: AppState_v2_0.versionKey)
       }
       
     }

--- a/Jewel/Services/StatePersitenceManager.swift
+++ b/Jewel/Services/StatePersitenceManager.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import os.log
 
 struct StatePersitenceManager {
   
@@ -20,7 +19,7 @@ struct StatePersitenceManager {
       let encodedState = try encoder.encode(state)
       UserDefaults.standard.set(encodedState, forKey: stateVersionKey)
     } catch {
-      os_log("💎 State > Error saving state: %s", error.localizedDescription)
+      JewelLogger.persistence.debug("💎 Persistence > Error saving state: \(error.localizedDescription)")
     }
   }
   
@@ -32,19 +31,19 @@ struct StatePersitenceManager {
   
   private static func oldSavedState() -> AppState? {
     
-    os_log("💎 State > Looking for a pre-2.1.0 saved state")
+    JewelLogger.persistence.info("💎 Persistence > Looking for a pre-2.1.0 saved state")
     guard let oldSavedState = UserDefaults.standard.object(forKey: "jewelState") as? Data else {
-      os_log("💎 State > No pre-2.1.0 saved state found")
+      JewelLogger.persistence.info("💎 Persistence > No pre-2.1.0 saved state found")
       return nil
     }
     
-    os_log("💎 State > Found a pre-2.1.0 saved state, migrating")
+    JewelLogger.persistence.info("💎 Persistence > Found a pre-2.1.0 saved state, migrating")
     if let state = migrateOldSavedState(oldSavedState) {
-      os_log("💎 State > Migration successful, deleting pre-2.1.0 saved state")
+      JewelLogger.persistence.info("💎 Persistence > Migration successful, deleting pre-2.1.0 saved state")
       UserDefaults.standard.removeObject(forKey: "jewelState")
       return state
     } else {
-      os_log("💎 State > Migration failed")
+      JewelLogger.persistence.info("💎 Persistence > Migration failed")
       return nil
     }
     
@@ -78,30 +77,30 @@ struct StatePersitenceManager {
       return newState
       
     } catch {
-      os_log("💎 State > Error decoding a pre-2.1.0 state: %s", error.localizedDescription)
+      JewelLogger.persistence.debug("💎 Persistence > Error decoding a pre-2.1.0 state: \(error.localizedDescription)")
       return nil
     }
   }
   
   static func savedState() -> AppState? {
 
-    os_log("💎 State > Looking for a current saved state")
+    JewelLogger.persistence.info("💎 Persistence > Looking for a current saved state")
     guard let savedState = UserDefaults.standard.object(forKey: stateVersionKey) as? Data else {
-      os_log("💎 State > No current saved state found")
+      JewelLogger.persistence.info("💎 Persistence > No current saved state found")
       return nil
     }
     
-    os_log("💎 State > Found a current saved state")
+    JewelLogger.persistence.info("💎 Persistence > Found a current saved state")
     do {
       let decoder = JSONDecoder()
       decoder.keyDecodingStrategy = .convertFromSnakeCase
       var state = try decoder.decode(AppState.self, from: savedState)
       state.navigation.onRotationId = state.library.onRotation.id
       state.navigation.activeStackId = state.library.onRotation.id
-      os_log("💎 State > Loaded a current saved state")
+      JewelLogger.persistence.info("💎 Persistence > Loaded a current saved state")
       return state
     } catch {
-      os_log("💎 State > Error decoding a current saved state: %s", error.localizedDescription)
+      JewelLogger.persistence.debug("💎 Persistence > Error decoding a current saved state: \(error.localizedDescription)")
       return nil
     }
     
@@ -109,13 +108,13 @@ struct StatePersitenceManager {
   
   static func newState() -> AppState {
     
-    os_log("💎 State > Creating a new state")
+    JewelLogger.persistence.info("💎 Persistence > Creating a new state")
     let onRotationStack = Stack(name: Navigation.Tab.onRotation.rawValue)
     let library = Library(onRotation: onRotationStack, stacks: [Stack]())
     var state = AppState(settings: Settings(), library: library)
     state.navigation.onRotationId = onRotationStack.id
     state.navigation.activeStackId = onRotationStack.id
-    os_log("💎 State > Created a new state")
+    JewelLogger.persistence.info("💎 Persistence > Created a new state")
     return state
   }
   

--- a/Jewel/Services/StatePersitenceManager.swift
+++ b/Jewel/Services/StatePersitenceManager.swift
@@ -61,19 +61,19 @@ struct StatePersitenceManager {
       newState.settings.firstTimeRun = false
       newState.settings.preferredMusicPlatform = OdesliPlatform.allCases[oldState.settings.preferredMusicPlatform]
       
-      let newOnRotation = Collection(id: oldState.library.onRotation.id,
+      let newOnRotation = Stack(id: oldState.library.onRotation.id,
                                            name: oldState.library.onRotation.name,
                                            slots: oldState.library.onRotation.slots)
       newState.library.onRotation = newOnRotation
       
-      var newCollections = [Collection]()
-      for oldCollection in oldState.library.collections {
-        let newCollection = Collection(id: oldCollection.id,
+      var newStacks = [Stack]()
+      for oldCollection in oldState.library.collections {  // From v3.0 Collections were renamed Stacks
+        let newStack = Stack(id: oldCollection.id,
                                        name: oldCollection.name,
                                        slots: oldCollection.slots)
-        newCollections.append(newCollection)
+        newStacks.append(newStack)
       }
-      newState.library.collections = newCollections
+      newState.library.stacks = newStacks
       
       return newState
       
@@ -97,7 +97,7 @@ struct StatePersitenceManager {
       decoder.keyDecodingStrategy = .convertFromSnakeCase
       var state = try decoder.decode(AppState.self, from: savedState)
       state.navigation.onRotationId = state.library.onRotation.id
-      state.navigation.activeCollectionId = state.library.onRotation.id
+      state.navigation.activeStackId = state.library.onRotation.id
       os_log("💎 State > Loaded a current saved state")
       return state
     } catch {
@@ -110,11 +110,11 @@ struct StatePersitenceManager {
   static func newState() -> AppState {
     
     os_log("💎 State > Creating a new state")
-    let onRotationCollection = Collection(name: Navigation.Tab.onRotation.rawValue)
-    let library = Library(onRotation: onRotationCollection, collections: [Collection]())
+    let onRotationStack = Stack(name: Navigation.Tab.onRotation.rawValue)
+    let library = Library(onRotation: onRotationStack, stacks: [Stack]())
     var state = AppState(settings: Settings(), library: library)
-    state.navigation.onRotationId = onRotationCollection.id
-    state.navigation.activeCollectionId = onRotationCollection.id
+    state.navigation.onRotationId = onRotationStack.id
+    state.navigation.activeStackId = onRotationStack.id
     os_log("💎 State > Created a new state")
     return state
   }

--- a/Jewel/Services/StatePersitenceManager.swift
+++ b/Jewel/Services/StatePersitenceManager.swift
@@ -72,6 +72,8 @@ struct StatePersitenceManager {
     fileprivate static func runMigrations() {
       migrateV2p0ToV2p1()
       migrateV2p1ToV3p0()
+      
+      UserDefaults.standard.synchronize()
     }
     
     private static func migrateV2p1ToV3p0() {
@@ -137,7 +139,9 @@ struct StatePersitenceManager {
         
       } catch {
         JewelLogger.persistence.debug("💎 Persistence > Error migrating a v2.1 state: \(error.localizedDescription)")
-        return
+        // Something's gone wrong and we haven't handled it, but now a new state will be created and take precedence
+        // so to avoid future problems we should remove the remnants of the old state.
+        UserDefaults.standard.removeObject(forKey: "jewelState_2_1")
       }
       
     }
@@ -207,6 +211,9 @@ struct StatePersitenceManager {
         
       } catch {
         JewelLogger.persistence.debug("💎 Persistence > Error migrating a v2.0 state: \(error.localizedDescription)")
+        // Something's gone wrong and we haven't handled it, but now a new state will be created and take precedence
+        // so to avoid future problems we should remove the remnants of the old state.
+        UserDefaults.standard.removeObject(forKey: "jewelState")
       }
       
     }

--- a/Jewel/State/AppState.swift
+++ b/Jewel/State/AppState.swift
@@ -11,6 +11,8 @@ import MusicKit
 
 struct AppState: Codable {
   
+  static let versionKey = "jewelState_v3_0"
+  
   var navigation = Navigation()
   
   var settings: Settings

--- a/Jewel/State/Library.swift
+++ b/Jewel/State/Library.swift
@@ -10,11 +10,11 @@ import Foundation
 
 struct Library: Codable {
   
-  var onRotation: Collection
-  var collections: [Collection]
+  var onRotation: Stack
+  var stacks: [Stack]
   
   enum CodingKeys: CodingKey {
     case onRotation
-    case collections
+    case stacks
   }
 }

--- a/Jewel/State/Navigation.swift
+++ b/Jewel/State/Navigation.swift
@@ -12,21 +12,21 @@ import SwiftUI
 struct Navigation {
   
   var onRotationId: UUID?
-  var activeCollectionId: UUID?
+  var activeStackId: UUID?
   var activeSlotIndex: Int = 0
   
   var onRotationActive: Bool {
-    onRotationId == activeCollectionId
+    onRotationId == activeStackId
   }
   
   var selectedTab: Navigation.Tab = .onRotation {
     didSet {
-      activeCollectionId = onRotationId
+      activeStackId = onRotationId
     }
   }
   enum Tab: String {
     case onRotation = "On Rotation"
-    case library = "Collections"
+    case library = "Stacks"
   }
   
   var showSearch: Bool = false
@@ -37,8 +37,8 @@ struct Navigation {
   var gettingPlaybackLinks: Bool = false
   var gettingSearchResults: Bool = false
   
-  var showCollection: Bool = false
-  var showCollectionOptions: Bool = false
+  var showStack: Bool = false
+  var showStackOptions: Bool = false
   
   var showLibraryOptions: Bool = false
   
@@ -46,13 +46,13 @@ struct Navigation {
   var showDebugMenu: Bool = false
   
   var libraryViewHeight: CGFloat = 812
-  var collectionCardHeight: CGFloat {
+  var stackCardHeight: CGFloat {
     cardHeightFor(libraryViewHeight)
   }
   
-  var collectionViewHeight: CGFloat = 812
+  var stackViewHeight: CGFloat = 812
   var albumCardHeight: CGFloat {
-    cardHeightFor(collectionViewHeight)
+    cardHeightFor(stackViewHeight)
   }
   
   private func cardHeightFor(_ viewHeight: CGFloat) -> CGFloat {

--- a/Jewel/State/OldAppState.swift
+++ b/Jewel/State/OldAppState.swift
@@ -24,16 +24,16 @@ struct OldAppState: Codable {
   struct Navigation {
     
     var onRotationId: UUID?
-    var activeCollectionId: UUID?
+    var activeStackId: UUID?
     var activeSlotIndex: Int = 0
     
     var onRotationActive: Bool {
-      onRotationId == activeCollectionId
+      onRotationId == activeStackId
     }
     
     var selectedTab: Navigation.Tab = .onRotation {
       didSet {
-        activeCollectionId = onRotationId
+        activeStackId = onRotationId
       }
     }
     enum Tab: String {

--- a/Jewel/State/OldAppState.swift
+++ b/Jewel/State/OldAppState.swift
@@ -24,16 +24,16 @@ struct OldAppState: Codable {
   struct Navigation {
     
     var onRotationId: UUID?
-    var activeStackId: UUID?
+    var activeCollectionId: UUID?
     var activeSlotIndex: Int = 0
     
     var onRotationActive: Bool {
-      onRotationId == activeStackId
+      onRotationId == activeCollectionId
     }
     
     var selectedTab: Navigation.Tab = .onRotation {
       didSet {
-        activeStackId = onRotationId
+        activeCollectionId = onRotationId
       }
     }
     enum Tab: String {

--- a/Jewel/State/Previous/AppStateV2p0.swift
+++ b/Jewel/State/Previous/AppStateV2p0.swift
@@ -1,5 +1,5 @@
 //
-//  OldAppState.swift
+//  AppStateV2p0.swift
 //  Stacks
 //
 //  Created by Greg Hepworth on 29/08/2023.
@@ -7,13 +7,14 @@
 //
 
 import Foundation
+import MusicKit
 
-struct OldAppState: Codable {
+struct AppStateV2p0: Codable {
   
-  var navigation = OldAppState.Navigation()
+  var navigation = AppStateV2p0.Navigation()
   
-  var settings: OldAppState.Settings
-  var library: OldAppState.Library
+  var settings: AppStateV2p0.Settings
+  var library: AppStateV2p0.Library
   var search = Search()
   
   enum CodingKeys: String, CodingKey {
@@ -85,10 +86,10 @@ struct OldAppState: Codable {
   
   struct Library: Codable {
     
-    var onRotation: OldAppState.Collection
+    var onRotation: AppStateV2p0.Collection
     
-    var collections: [OldAppState.Collection]
-    var cuedCollection: OldAppState.Library.SharedCollectionManager.ShareableCollection?
+    var collections: [AppStateV2p0.Collection]
+    var cuedCollection: AppStateV2p0.Library.SharedCollectionManager.ShareableCollection?
     
     class SharedCollectionManager {
       
@@ -97,7 +98,7 @@ struct OldAppState: Codable {
         let schemaVersion: Decimal = 1.1
         let collectionName: String
         let collectionCurator: String
-        let collection: [OldAppState.Library.SharedCollectionManager.ShareableSlot?]
+        let collection: [AppStateV2p0.Library.SharedCollectionManager.ShareableSlot?]
         
         enum CodingKeys: String, CodingKey {
           case schemaName = "sn"
@@ -109,7 +110,7 @@ struct OldAppState: Codable {
       }
       
       struct ShareableSlot: Codable {
-        let albumProvider: OldAppState.Library.SharedCollectionManager.ShareableSlot.AlbumProvider
+        let albumProvider: AppStateV2p0.Library.SharedCollectionManager.ShareableSlot.AlbumProvider
         let albumRef: String
         
         enum AlbumProvider: String, Codable {
@@ -126,13 +127,13 @@ struct OldAppState: Codable {
   
   struct Collection: Identifiable, Codable {
     var id = UUID()
-    var type: OldAppState.Collection.CollectionType
+    var type: AppStateV2p0.Collection.CollectionType
     var name: String
     var curator: String
-    var slots: [Slot] = {
-      var tmpSlots = [Slot]()
+    var slots: [AppStateV2p0.Slot] = {
+      var tmpSlots = [AppStateV2p0.Slot]()
       for _ in 0..<8 {
-        let slot = Slot()
+        let slot = AppStateV2p0.Slot()
         tmpSlots.append(slot)
       }
       return tmpSlots
@@ -144,6 +145,18 @@ struct OldAppState: Codable {
     enum CollectionType: String, Codable {
       case userCollection
       case sharedCollection
+    }
+  }
+  
+  struct Slot: Identifiable, Codable {
+    var id = UUID()
+    var album: Album?
+    var playbackLinks: OdesliResponse?
+    
+    enum CodingKeys: String, CodingKey {
+      case id
+      case album = "source"
+      case playbackLinks
     }
   }
   

--- a/Jewel/State/Previous/AppStateV2p1.swift
+++ b/Jewel/State/Previous/AppStateV2p1.swift
@@ -1,0 +1,125 @@
+//
+//  AppStateV2p1.swift
+//  Stacks
+//
+//  Created by Greg Hepworth on 01/01/2024.
+//  Copyright © 2024 Breakbeat Ltd. All rights reserved.
+//
+
+import Foundation
+import MusicKit
+
+struct AppStateV2p1: Codable {
+  
+  var navigation = AppStateV2p1.Navigation()
+  
+  var settings: AppStateV2p1.Settings
+  var library: AppStateV2p1.Library
+  var search = Search()
+  
+  enum CodingKeys: String, CodingKey {
+    case settings = "options"
+    case library
+  }
+  
+  struct Navigation {
+    
+    var onRotationId: UUID?
+    var activeCollectionId: UUID?
+    var activeSlotIndex: Int = 0
+    
+    var onRotationActive: Bool {
+      onRotationId == activeCollectionId
+    }
+    
+    var selectedTab: Navigation.Tab = .onRotation {
+      didSet {
+        activeCollectionId = onRotationId
+      }
+    }
+    enum Tab: String {
+      case onRotation = "On Rotation"
+      case library = "Collections"
+    }
+    
+    var showSearch: Bool = false
+    
+    var showAlbumDetail: Bool = false
+    var showPlaybackLinks: Bool = false
+    
+    var gettingPlaybackLinks: Bool = false
+    var gettingSearchResults: Bool = false
+    
+    var showCollection: Bool = false
+    var showCollectionOptions: Bool = false
+    
+    var showLibraryOptions: Bool = false
+    
+    var showSettings: Bool = false
+    var showDebugMenu: Bool = false
+    
+    var libraryViewHeight: CGFloat = 812
+    var collectionCardHeight: CGFloat {
+      cardHeightFor(libraryViewHeight)
+    }
+    
+    var collectionViewHeight: CGFloat = 812
+    var albumCardHeight: CGFloat {
+      cardHeightFor(collectionViewHeight)
+    }
+    
+    private func cardHeightFor(_ viewHeight: CGFloat) -> CGFloat {
+      let height = (viewHeight - 200) / 8
+      return height < 61 ? 61 : height
+    }
+    
+  }
+  
+  struct Settings: Codable {
+    var preferredMusicPlatform: OdesliPlatform = .appleMusic
+    var firstTimeRun: Bool = true
+  }
+  
+  struct Library: Codable {
+    
+    var onRotation: AppStateV2p1.Collection
+    var collections: [AppStateV2p1.Collection]
+    
+    enum CodingKeys: CodingKey {
+      case onRotation
+      case collections
+    }
+  }
+  
+  struct Collection: Identifiable, Codable {
+    var id = UUID()
+    var name: String
+    var slots: [AppStateV2p1.Slot] = {
+      var tmpSlots = [AppStateV2p1.Slot]()
+      for _ in 0..<8 {
+        let slot = AppStateV2p1.Slot()
+        tmpSlots.append(slot)
+      }
+      return tmpSlots
+    }()
+    
+    enum CodingKeys: CodingKey {
+      case id
+      case name
+      case slots
+    }
+  }
+  
+  struct Slot: Identifiable, Codable {
+    var id = UUID()
+    var album: Album?
+    var playbackLinks: OdesliResponse?
+    
+    enum CodingKeys: String, CodingKey {
+      case id
+      case album = "source"
+      case playbackLinks
+    }
+  }
+  
+}

--- a/Jewel/State/Previous/AppState_v2_0.swift
+++ b/Jewel/State/Previous/AppState_v2_0.swift
@@ -1,5 +1,5 @@
 //
-//  AppStateV2p0.swift
+//  AppState_v2_0.swift
 //  Stacks
 //
 //  Created by Greg Hepworth on 29/08/2023.
@@ -9,12 +9,12 @@
 import Foundation
 import MusicKit
 
-struct AppStateV2p0: Codable {
+struct AppState_v2_0: Codable {
   
-  var navigation = AppStateV2p0.Navigation()
+  var navigation = AppState_v2_0.Navigation()
   
-  var settings: AppStateV2p0.Settings
-  var library: AppStateV2p0.Library
+  var settings: AppState_v2_0.Settings
+  var library: AppState_v2_0.Library
   var search = Search()
   
   enum CodingKeys: String, CodingKey {
@@ -86,10 +86,10 @@ struct AppStateV2p0: Codable {
   
   struct Library: Codable {
     
-    var onRotation: AppStateV2p0.Collection
+    var onRotation: AppState_v2_0.Collection
     
-    var collections: [AppStateV2p0.Collection]
-    var cuedCollection: AppStateV2p0.Library.SharedCollectionManager.ShareableCollection?
+    var collections: [AppState_v2_0.Collection]
+    var cuedCollection: AppState_v2_0.Library.SharedCollectionManager.ShareableCollection?
     
     class SharedCollectionManager {
       
@@ -98,7 +98,7 @@ struct AppStateV2p0: Codable {
         let schemaVersion: Decimal = 1.1
         let collectionName: String
         let collectionCurator: String
-        let collection: [AppStateV2p0.Library.SharedCollectionManager.ShareableSlot?]
+        let collection: [AppState_v2_0.Library.SharedCollectionManager.ShareableSlot?]
         
         enum CodingKeys: String, CodingKey {
           case schemaName = "sn"
@@ -110,7 +110,7 @@ struct AppStateV2p0: Codable {
       }
       
       struct ShareableSlot: Codable {
-        let albumProvider: AppStateV2p0.Library.SharedCollectionManager.ShareableSlot.AlbumProvider
+        let albumProvider: AppState_v2_0.Library.SharedCollectionManager.ShareableSlot.AlbumProvider
         let albumRef: String
         
         enum AlbumProvider: String, Codable {
@@ -127,13 +127,13 @@ struct AppStateV2p0: Codable {
   
   struct Collection: Identifiable, Codable {
     var id = UUID()
-    var type: AppStateV2p0.Collection.CollectionType
+    var type: AppState_v2_0.Collection.CollectionType
     var name: String
     var curator: String
-    var slots: [AppStateV2p0.Slot] = {
-      var tmpSlots = [AppStateV2p0.Slot]()
+    var slots: [AppState_v2_0.Slot] = {
+      var tmpSlots = [AppState_v2_0.Slot]()
       for _ in 0..<8 {
-        let slot = AppStateV2p0.Slot()
+        let slot = AppState_v2_0.Slot()
         tmpSlots.append(slot)
       }
       return tmpSlots

--- a/Jewel/State/Previous/AppState_v2_0.swift
+++ b/Jewel/State/Previous/AppState_v2_0.swift
@@ -11,6 +11,8 @@ import MusicKit
 
 struct AppState_v2_0: Codable {
   
+  static let versionKey = "jewelState"
+  
   var navigation = AppState_v2_0.Navigation()
   
   var settings: AppState_v2_0.Settings

--- a/Jewel/State/Previous/AppState_v2_1.swift
+++ b/Jewel/State/Previous/AppState_v2_1.swift
@@ -11,6 +11,8 @@ import MusicKit
 
 struct AppState_v2_1: Codable {
   
+  static let versionKey = "jewelState_2_1"
+  
   var navigation = AppState_v2_1.Navigation()
   
   var settings: AppState_v2_1.Settings

--- a/Jewel/State/Previous/AppState_v2_1.swift
+++ b/Jewel/State/Previous/AppState_v2_1.swift
@@ -1,5 +1,5 @@
 //
-//  AppStateV2p1.swift
+//  AppState_v2_1.swift
 //  Stacks
 //
 //  Created by Greg Hepworth on 01/01/2024.
@@ -9,12 +9,12 @@
 import Foundation
 import MusicKit
 
-struct AppStateV2p1: Codable {
+struct AppState_v2_1: Codable {
   
-  var navigation = AppStateV2p1.Navigation()
+  var navigation = AppState_v2_1.Navigation()
   
-  var settings: AppStateV2p1.Settings
-  var library: AppStateV2p1.Library
+  var settings: AppState_v2_1.Settings
+  var library: AppState_v2_1.Library
   var search = Search()
   
   enum CodingKeys: String, CodingKey {
@@ -82,8 +82,8 @@ struct AppStateV2p1: Codable {
   
   struct Library: Codable {
     
-    var onRotation: AppStateV2p1.Collection
-    var collections: [AppStateV2p1.Collection]
+    var onRotation: AppState_v2_1.Collection
+    var collections: [AppState_v2_1.Collection]
     
     enum CodingKeys: CodingKey {
       case onRotation
@@ -94,10 +94,10 @@ struct AppStateV2p1: Codable {
   struct Collection: Identifiable, Codable {
     var id = UUID()
     var name: String
-    var slots: [AppStateV2p1.Slot] = {
-      var tmpSlots = [AppStateV2p1.Slot]()
+    var slots: [AppState_v2_1.Slot] = {
+      var tmpSlots = [AppState_v2_1.Slot]()
       for _ in 0..<8 {
-        let slot = AppStateV2p1.Slot()
+        let slot = AppState_v2_1.Slot()
         tmpSlots.append(slot)
       }
       return tmpSlots

--- a/Jewel/State/Stack.swift
+++ b/Jewel/State/Stack.swift
@@ -1,5 +1,5 @@
 //
-//  CollectionState.swift
+//  Stack.swift
 //  Jewel
 //
 //  Created by Greg Hepworth on 01/06/2020.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Collection: Identifiable, Codable {
+struct Stack: Identifiable, Codable {
   var id = UUID()
   var name: String
   var slots: [Slot] = {

--- a/Jewel/Views/Components/AddAlbumCardButton.swift
+++ b/Jewel/Views/Components/AddAlbumCardButton.swift
@@ -13,11 +13,11 @@ struct AddAlbumCardButton: View {
   @EnvironmentObject var app: AppEnvironment
   
   let slotIndex: Int
-  let collectionId: UUID
+  let stackId: UUID
   
   var body: some View {
     Button {
-      app.update(action: NavigationAction.setActiveCollectionId(collectionId: collectionId))
+      app.update(action: NavigationAction.setActiveStackId(stackId: stackId))
       app.update(action: NavigationAction.setActiveSlotIndex(slotIndex: slotIndex))
       app.update(action: NavigationAction.showSearch(true))
     } label: {

--- a/Jewel/Views/Components/AlbumDetail.swift
+++ b/Jewel/Views/Components/AlbumDetail.swift
@@ -15,16 +15,16 @@ struct AlbumDetail: View {
   
   @EnvironmentObject var app: AppEnvironment
   
-  private var collection: Collection {
+  private var stack: Stack {
     if app.state.navigation.onRotationActive {
       return app.state.library.onRotation
     } else {
-      return app.state.library.collections.first(where: { $0.id == app.state.navigation.activeCollectionId })!
+      return app.state.library.stacks.first(where: { $0.id == app.state.navigation.activeStackId })!
     }
   }
   
   private var slot: Slot {
-    collection.slots[app.state.navigation.activeSlotIndex]
+    stack.slots[app.state.navigation.activeSlotIndex]
   }
   
   var body: some View {
@@ -47,7 +47,7 @@ struct AlbumDetail: View {
           },
         trailing:
           Button {
-            app.update(action: LibraryAction.removeAlbumFromSlot(slotIndex: app.state.navigation.activeSlotIndex, collectionId: app.state.navigation.activeCollectionId!))
+            app.update(action: LibraryAction.removeAlbumFromSlot(slotIndex: app.state.navigation.activeSlotIndex, stackId: app.state.navigation.activeStackId!))
             app.update(action: NavigationAction.showAlbumDetail(false))
           } label: {
             Text(Image(systemName: "eject"))

--- a/Jewel/Views/Components/CardArtworkComposite.swift
+++ b/Jewel/Views/Components/CardArtworkComposite.swift
@@ -1,5 +1,5 @@
 //
-//  CollectionArtworkComposite.swift
+//  CardArtworkComposite.swift
 //  Stacks
 //
 //  Created by Greg Hepworth on 05/06/2020.

--- a/Jewel/Views/Components/StackCard.swift
+++ b/Jewel/Views/Components/StackCard.swift
@@ -1,5 +1,5 @@
 //
-//  CollectionCard.swift
+//  StackCard.swift
 //  Stacks
 //
 //  Created by Greg Hepworth on 05/06/2020.
@@ -8,15 +8,15 @@
 
 import SwiftUI
 
-struct CollectionCard: View {
+struct StackCard: View {
   
   @EnvironmentObject var app: AppEnvironment
   
-  let collection: Collection
+  let stack: Stack
   
-  private var collectionArtwork: [URL] {
+  private var stackArtwork: [URL] {
     var artworkUrls = [URL]()
-    for slot in collection.slots {
+    for slot in stack.slots {
       if let artworkUrl = slot.album?.artwork?.url(width: 1000, height: 1000) {
         artworkUrls.append(artworkUrl)
       }
@@ -26,19 +26,19 @@ struct CollectionCard: View {
   
   var body: some View {
     Button {
-      app.update(action: NavigationAction.setActiveCollectionId(collectionId: collection.id))
-      app.update(action: NavigationAction.showCollection(true))
+      app.update(action: NavigationAction.setActiveStackId(stackId: stack.id))
+      app.update(action: NavigationAction.showStack(true))
     } label: {
       ZStack(alignment: .bottom) {
         Rectangle()
           .foregroundColor(.clear)
           .background(
-            CardArtworkComposite(images: collectionArtwork)
+            CardArtworkComposite(images: stackArtwork)
           )
           .cornerRadius(Constants.cardCornerRadius)
           .shadow(radius: 3)
         HStack(alignment: .bottom) {
-          Text(collection.name)
+          Text(stack.name)
             .font(.callout)
             .fontWeight(.bold)
             .foregroundColor(.white)

--- a/Jewel/Views/Components/StackDetail.swift
+++ b/Jewel/Views/Components/StackDetail.swift
@@ -1,5 +1,5 @@
 //
-//  EditableAlbumList.swift
+//  StackDetail.swift
 //  Stacks
 //
 //  Created by Greg Hepworth on 17/06/2020.
@@ -8,13 +8,13 @@
 
 import SwiftUI
 
-struct CollectionDetail: View {
+struct StackDetail: View {
   
   @Environment(\.horizontalSizeClass) var horizontalSizeClass
   
   @EnvironmentObject var app: AppEnvironment
   
-  var collection: Collection
+  var stack: Stack
 
   private var showSheet: Binding<Bool> { Binding (
     get: { app.state.navigation.showAlbumDetail || app.state.navigation.showSearch },
@@ -24,10 +24,10 @@ struct CollectionDetail: View {
   }
     )}
   private var slots: [Slot] {
-    collection.slots
+    stack.slots
   }
-  private var collectionEmpty: Bool {
-    collection.slots.filter( { $0.album != nil }).count == 0
+  private var stackEmpty: Bool {
+    stack.slots.filter( { $0.album != nil }).count == 0
   }
   
   var body: some View {
@@ -37,7 +37,7 @@ struct CollectionDetail: View {
           Spacer()
         }
         ScrollView {
-          Text(collection.name)
+          Text(stack.name)
             .font(.title)
             .fontWeight(.bold)
             .padding(.top)
@@ -54,14 +54,14 @@ struct CollectionDetail: View {
                   }
                 }
               } else {
-                AddAlbumCardButton(slotIndex: slotIndex, collectionId: collection.id)
+                AddAlbumCardButton(slotIndex: slotIndex, stackId: stack.id)
               }
             }
             .frame(height: app.state.navigation.albumCardHeight)
           }
         }
         .padding(.horizontal)
-        .frame(maxWidth: horizontalSizeClass == .regular && !app.state.navigation.showCollection ? Constants.regularMaxWidth : .infinity)
+        .frame(maxWidth: horizontalSizeClass == .regular && !app.state.navigation.showStack ? Constants.regularMaxWidth : .infinity)
         if horizontalSizeClass == .regular {
           Spacer()
         }
@@ -77,14 +77,14 @@ struct CollectionDetail: View {
         }
       }
       .onAppear {
-        if geo.size.height != app.state.navigation.collectionViewHeight {
-          app.update(action: NavigationAction.setCollectionViewHeight(viewHeight: geo.size.height))
+        if geo.size.height != app.state.navigation.stackViewHeight {
+          app.update(action: NavigationAction.setStackViewHeight(viewHeight: geo.size.height))
         }
       }
       .onDisappear {
-        if !app.state.navigation.onRotationActive && collectionEmpty {
-          app.update(action: NavigationAction.setActiveCollectionId(collectionId: app.state.navigation.onRotationId!))
-          app.update(action: LibraryAction.removeCollection(collectionId: collection.id))
+        if !app.state.navigation.onRotationActive && stackEmpty {
+          app.update(action: NavigationAction.setActiveStackId(stackId: app.state.navigation.onRotationId!))
+          app.update(action: LibraryAction.removeStack(stackId: stack.id))
         }
       }
     }

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -25,15 +25,14 @@ struct Home: View {
           if app.state.navigation.selectedTab == .onRotation {
             OnRotation()
               .transition(.move(edge: .leading))
-              .animation(.easeOut)
           }
           if app.state.navigation.selectedTab == .library {
             StackLibrary()
               .transition(.move(edge: .trailing))
-              .animation(.easeOut)
           }
         }
         .background(Color(UIColor.systemBackground))
+        .animation(.easeOut, value: app.state.navigation.selectedTab)
       }
       .disabled(app.state.settings.firstTimeRun)
       .blur(radius: app.state.settings.firstTimeRun ? 10 : 0)

--- a/Jewel/Views/Home.swift
+++ b/Jewel/Views/Home.swift
@@ -28,7 +28,7 @@ struct Home: View {
               .animation(.easeOut)
           }
           if app.state.navigation.selectedTab == .library {
-            CollectionLibrary()
+            StackLibrary()
               .transition(.move(edge: .trailing))
               .animation(.easeOut)
           }

--- a/Jewel/Views/NavBar.swift
+++ b/Jewel/Views/NavBar.swift
@@ -32,7 +32,7 @@ struct NavBar: View {
         .frame(maxWidth: 300)
         Spacer()
         if app.state.navigation.selectedTab == .onRotation {
-          CollectionActionButtons()
+          StackActionButtons()
         } else {
           LibraryActionButtons()
         }
@@ -45,28 +45,28 @@ struct NavBar: View {
   }
 }
 
-struct CollectionActionButtons: View {
+struct StackActionButtons: View {
   
   @EnvironmentObject var app: AppEnvironment
   
-  private var showCollectionOptions: Binding<Bool> { Binding (
-    get: { app.state.navigation.showCollectionOptions },
-    set: { if app.state.navigation.showCollectionOptions { app.update(action: NavigationAction.showCollectionOptions($0)) } }
+  private var showStackOptions: Binding<Bool> { Binding (
+    get: { app.state.navigation.showStackOptions },
+    set: { if app.state.navigation.showStackOptions { app.update(action: NavigationAction.showStackOptions($0)) } }
   )}
   
   var body: some View {
     HStack {
       Spacer()
       Button {
-        app.update(action: NavigationAction.showCollectionOptions(true))
+        app.update(action: NavigationAction.showStackOptions(true))
       } label: {
         Text(Image(systemName: "ellipsis"))
           .font(.body)
           .foregroundColor(Color(UIColor.secondaryLabel))
       }
       .padding(.leading)
-      .sheet(isPresented: showCollectionOptions) {
-        CollectionOptions()
+      .sheet(isPresented: showStackOptions) {
+        StackOptions()
           .environmentObject(app)
       }
     }
@@ -83,9 +83,9 @@ struct LibraryActionButtons: View {
     HStack {
       Spacer()
       Button {
-        app.update(action: LibraryAction.createCollection)
-        app.update(action: NavigationAction.setActiveCollectionId(collectionId: app.state.library.collections.first!.id))
-        app.update(action: NavigationAction.showCollection(true))
+        app.update(action: LibraryAction.createStack)
+        app.update(action: NavigationAction.setActiveStackId(stackId: app.state.library.stacks.first!.id))
+        app.update(action: NavigationAction.showStack(true))
       } label: {
         Text(Image(systemName: "plus"))
           .font(.body)

--- a/Jewel/Views/OnRotation.swift
+++ b/Jewel/Views/OnRotation.swift
@@ -13,6 +13,6 @@ struct OnRotation: View {
   @EnvironmentObject var app: AppEnvironment
   
   var body: some View {
-    CollectionDetail(collection: app.state.library.onRotation)
+    StackDetail(stack: app.state.library.onRotation)
   }
 }

--- a/Jewel/Views/Options/StackOptions.swift
+++ b/Jewel/Views/Options/StackOptions.swift
@@ -8,44 +8,44 @@
 
 import SwiftUI
 
-struct CollectionOptions: View {
+struct StackOptions: View {
   
   @EnvironmentObject private var app: AppEnvironment
   
-  private var collection: Collection? {
+  private var stack: Stack? {
     if app.state.navigation.onRotationActive {
       return app.state.library.onRotation
     } else {
-      return app.state.library.collections.first(where: { $0.id == app.state.navigation.activeCollectionId })
+      return app.state.library.stacks.first(where: { $0.id == app.state.navigation.activeStackId })
     }
   }
-  private var collectionEmpty: Bool {
-    collection?.slots.filter( { $0.album != nil }).count == 0
+  private var stackEmpty: Bool {
+    stack?.slots.filter( { $0.album != nil }).count == 0
   }
   
-  @State private var newCollectionName: String = ""
+  @State private var newStackName: String = ""
   @FocusState private var nameFocussed: Bool
   
   var body: some View {
-    if let collection = collection { // this if has to be outside the NavigationView else LibraryAction.removeCollection creates an exception ¯\_(ツ)_/¯
+    if let stack = stack { // this if has to be outside the NavigationView else LibraryAction.removeStack creates an exception ¯\_(ツ)_/¯
       NavigationView {
         Form {
           if !app.state.navigation.onRotationActive {
             Section {
               HStack {
-                Text("Collection Name")
+                Text("Stack Name")
                   .font(.body)
                 TextField(
-                  collection.name,
-                  text: $newCollectionName
+                  stack.name,
+                  text: $newStackName
                 )
                 .focused($nameFocussed)
                 .onAppear {
-                  self.newCollectionName = collection.name
+                  self.newStackName = stack.name
                 }
                 .onChange(of: nameFocussed) { _ in
-                  if !newCollectionName.isEmpty && newCollectionName != collection.name {
-                    app.update(action: LibraryAction.setCollectionName(name: newCollectionName.trimmingCharacters(in: .whitespaces), collectionId: collection.id))
+                  if !newStackName.isEmpty && newStackName != stack.name {
+                    app.update(action: LibraryAction.setStackName(name: newStackName.trimmingCharacters(in: .whitespaces), stackId: stack.id))
                   }
                 }
                 .font(.body)
@@ -57,54 +57,54 @@ struct CollectionOptions: View {
             if app.state.navigation.onRotationActive {
               Button {
                 app.update(action: NavigationAction.switchTab(to: .library))
-                app.update(action: NavigationAction.showCollectionOptions(false))
-                app.update(action: LibraryAction.saveOnRotation(collection: app.state.library.onRotation))
+                app.update(action: NavigationAction.showStackOptions(false))
+                app.update(action: LibraryAction.saveOnRotation(stack: app.state.library.onRotation))
               } label: {
                 HStack {
                   Text(Image(systemName: "arrow.right.square"))
                     .font(.body)
                     .frame(width: Constants.optionsButtonIconWidth)
-                  Text("Save to Collections")
+                  Text("Save Stack")
                     .font(.body)
                 }
               }
             } else {
               Button {
-                app.update(action: LibraryAction.duplicateCollection(collection: collection))
-                app.update(action: NavigationAction.showCollectionOptions(false))
-                app.update(action: NavigationAction.showCollection(false))
+                app.update(action: LibraryAction.duplicateStack(stack: stack))
+                app.update(action: NavigationAction.showStackOptions(false))
+                app.update(action: NavigationAction.showStack(false))
               } label: {
                 HStack {
                   Text(Image(systemName: "doc.on.doc"))
                     .font(.body)
                     .frame(width: Constants.optionsButtonIconWidth)
-                  Text("Duplicate Collection")
+                  Text("Duplicate Stack")
                     .font(.body)
                 }
               }
               Button {
-                app.update(action: LibraryAction.removeCollection(collectionId: collection.id))
-                app.update(action: NavigationAction.showCollectionOptions(false))
-                app.update(action: NavigationAction.showCollection(false))
+                app.update(action: LibraryAction.removeStack(stackId: stack.id))
+                app.update(action: NavigationAction.showStackOptions(false))
+                app.update(action: NavigationAction.showStack(false))
               } label: {
                 HStack {
                   Text(Image(systemName: "delete.left"))
                     .font(.body)
                     .frame(width: Constants.optionsButtonIconWidth)
-                  Text("Delete Collection")
+                  Text("Delete Stack")
                     .font(.body)
                 }
-                .foregroundColor(collectionEmpty ? nil : .red)
+                .foregroundColor(stackEmpty ? nil : .red)
               }
             }
           }
-          .disabled(collectionEmpty)
+          .disabled(stackEmpty)
         }
-        .navigationBarTitle("\(app.state.navigation.onRotationActive ? Navigation.Tab.onRotation.rawValue : "Collection") Options", displayMode: .inline)
+        .navigationBarTitle("\(app.state.navigation.onRotationActive ? Navigation.Tab.onRotation.rawValue : "Stack") Options", displayMode: .inline)
         .navigationBarItems(
           leading:
             Button {
-              app.update(action: NavigationAction.showCollectionOptions(false))
+              app.update(action: NavigationAction.showStackOptions(false))
             } label: {
               Text("Close")
                 .font(.body)

--- a/Jewel/Views/Search/SearchHome.swift
+++ b/Jewel/Views/Search/SearchHome.swift
@@ -16,7 +16,7 @@ struct SearchHome: View {
     NavigationView {
       VStack{
         SearchBar()
-        SearchResults(collectionId: app.state.navigation.activeCollectionId!, slotIndex: app.state.navigation.activeSlotIndex)
+        SearchResults(stackId: app.state.navigation.activeStackId!, slotIndex: app.state.navigation.activeSlotIndex)
         Spacer()
       }
       .navigationBarTitle("Search")

--- a/Jewel/Views/Search/SearchResults.swift
+++ b/Jewel/Views/Search/SearchResults.swift
@@ -13,7 +13,7 @@ struct SearchResults: View {
   
   @EnvironmentObject var app: AppEnvironment
   
-  let collectionId: UUID
+  let stackId: UUID
   let slotIndex: Int
   
   private var searchResults: MusicItemCollection<Album>? {
@@ -64,12 +64,12 @@ struct SearchResults: View {
   private func addAlbum(withId albumId: MusicItemID) {
     Task {
       async let album = RecordStore.getAlbum(withId: albumId)
-      try? await app.update(action: LibraryAction.addAlbumToSlot(album: album, slotIndex: slotIndex, collectionId: collectionId))
+      try? await app.update(action: LibraryAction.addAlbumToSlot(album: album, slotIndex: slotIndex, stackId: stackId))
       
       if let baseUrl = try? await album.url {
         app.update(action: NavigationAction.gettingPlaybackLinks(true))
         async let playbackLinks = RecordStore.getPlaybackLinks(for: baseUrl)
-        try? app.update(action: LibraryAction.setPlaybackLinks(baseUrl: baseUrl, playbackLinks: await playbackLinks, collectionId: collectionId))
+        try? app.update(action: LibraryAction.setPlaybackLinks(baseUrl: baseUrl, playbackLinks: await playbackLinks, stackId: stackId))
         app.update(action: NavigationAction.gettingPlaybackLinks(false))
       }
     }

--- a/Jewel/Views/StackLibrary.swift
+++ b/Jewel/Views/StackLibrary.swift
@@ -1,5 +1,5 @@
 //
-//  CollectionLibrary.swift
+//  StackLibrary.swift
 //  Stacks
 //
 //  Created by Greg Hepworth on 22/06/2020.
@@ -8,19 +8,19 @@
 
 import SwiftUI
 
-struct CollectionLibrary: View {
+struct StackLibrary: View {
   
   @Environment(\.horizontalSizeClass) var horizontalSizeClass
   
   @EnvironmentObject var app: AppEnvironment
 
-  private var showCollection: Binding<Bool> { Binding (
-    get: { app.state.navigation.showCollection },
-    set: { if app.state.navigation.showCollection { app.update(action: NavigationAction.showCollection($0)) } }
+  private var showStack: Binding<Bool> { Binding (
+    get: { app.state.navigation.showStack },
+    set: { if app.state.navigation.showStack { app.update(action: NavigationAction.showStack($0)) } }
     )}
   
-  private var collections: [Collection] {
-    app.state.library.collections
+  private var stacks: [Stack] {
+    app.state.library.stacks
   }
   
   var body: some View {
@@ -30,25 +30,25 @@ struct CollectionLibrary: View {
           Spacer()
         }
         ScrollView {
-          Text("Collections")
+          Text("Stacks")
             .font(.title)
             .fontWeight(.bold)
             .frame(minWidth: 0, maxWidth: .infinity, alignment: .topLeading)
             .padding(.top)
-          if collections.isEmpty {
+          if stacks.isEmpty {
             VStack {
               Image(systemName: "music.note.list")
                 .font(.system(size: 40))
                 .padding(.bottom)
-              Text("Collections you have saved or created will appear here.")
+              Text("Stacks you have saved or created will appear here.")
                 .multilineTextAlignment(.center)
             }
             .padding()
             .foregroundColor(Color.secondary)
           } else {
-            ForEach(collections) { collection in
-              CollectionCard(collection: collection)
-                .frame(height: app.state.navigation.collectionCardHeight)
+            ForEach(stacks) { stack in
+              StackCard(stack: stack)
+                .frame(height: app.state.navigation.stackCardHeight)
             }
           }
         }
@@ -59,8 +59,8 @@ struct CollectionLibrary: View {
         }
       }
       .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
-      .sheet(isPresented: showCollection) {
-        CollectionSheet()
+      .sheet(isPresented: showStack) {
+        StackSheet()
           .environmentObject(app)
       }
       .onAppear {

--- a/Jewel/Views/StackSheet.swift
+++ b/Jewel/Views/StackSheet.swift
@@ -1,5 +1,5 @@
 //
-//  CollectionSheet.swift
+//  StackSheet.swift
 //  Stacks
 //
 //  Created by Greg Hepworth on 25/06/2020.
@@ -8,16 +8,16 @@
 
 import SwiftUI
 
-struct CollectionSheet: View {
+struct StackSheet: View {
   
   @EnvironmentObject var app: AppEnvironment
   
-  private var collection: Collection? {
+  private var stack: Stack? {
     if app.state.navigation.onRotationActive {
       return app.state.library.onRotation
     } else {
-      if let collectionIndex = app.state.library.collections.firstIndex(where: { $0.id == app.state.navigation.activeCollectionId }) {
-        return app.state.library.collections[collectionIndex]
+      if let stackIndex = app.state.library.stacks.firstIndex(where: { $0.id == app.state.navigation.activeStackId }) {
+        return app.state.library.stacks[stackIndex]
       }
       return nil
     }
@@ -25,18 +25,18 @@ struct CollectionSheet: View {
   
   var body: some View {
     NavigationView {
-      if let collection = collection { // this IfLet has to be inside the NavigationView else the sheet isn't dismissed on removeCollection in CollectionOptions ¯\_(ツ)_/¯
-        CollectionDetail(collection: collection)
+      if let stack = stack { // this IfLet has to be inside the NavigationView else the sheet isn't dismissed on removeStack in StackOptions ¯\_(ツ)_/¯
+        StackDetail(stack: stack)
           .navigationBarTitle("", displayMode: .inline)
           .navigationBarItems(
             leading:
               Button {
-                app.update(action: NavigationAction.showCollection(false))
+                app.update(action: NavigationAction.showStack(false))
               } label: {
                 Text("Close")
                   .font(.body)
               },
-            trailing: CollectionActionButtons()
+            trailing: StackActionButtons()
           )
           .navigationViewStyle(StackNavigationViewStyle())
       }

--- a/Jewel/Views/Welcome.swift
+++ b/Jewel/Views/Welcome.swift
@@ -16,11 +16,11 @@ struct Welcome: View {
   private let description = """
   Stacks is a reminder and album curation app for your music.
 
-  Add music to your On Rotation collection as a reminder to listen later.
+  Add music to your On Rotation stack as a reminder to listen later.
 
-  Save as a Collection to curate sets of albums that represent a theme or time you don't want to forget.
+  Save Stacks to curate sets of albums that represent a theme or time you don't want to forget.
   """
-  private let startCollectionLabel = "Start My Collection"
+  private let startStackLabel = "Start Creating Stacks"
   
   var body: some View {
     RichAlert(heading: heading,
@@ -28,7 +28,7 @@ struct Welcome: View {
       Button {
         app.update(action: SettingsAction.firstTimeRun(false))
       } label: {
-        Text(startCollectionLabel)
+        Text(startStackLabel)
           .fontWeight(.bold)
       })
     {


### PR DESCRIPTION
Migrates the model to use the language of Stacks instead of a Collection.  Functionally everything is the same, but did not want to have the model not represent the views or have mixed language.  This nix'es all the use of Collection.

It includes a small refactor to the saved state migration so that v2 and v2.1 users will (should) not lose data.

Also fixes that animation warning that has been bugging me!